### PR TITLE
Fix "Test class can only have one constructor"-problem

### DIFF
--- a/core/src/test/java/org/powermock/core/transformers/impl/MainMockTransformerTest.java
+++ b/core/src/test/java/org/powermock/core/transformers/impl/MainMockTransformerTest.java
@@ -23,8 +23,11 @@ import org.powermock.core.transformers.MockTransformer;
 import powermock.test.support.MainMockTransformerTestSupport.SupportClasses;
 
 import java.util.Collections;
+import org.powermock.core.IndicateReloadClass;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 public class MainMockTransformerTest {
     /**
@@ -69,5 +72,18 @@ public class MainMockTransformerTest {
         mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new MainMockTransformer()));
         final Class<?> clazz = Class.forName(SupportClasses.class.getName() + "$PrivateStaticFinalInnerClass", true, mockClassLoader);
         assertFalse(Modifier.isFinal(clazz.getModifiers()));
+    }
+
+    @Test
+    public void subclassShouldNormallyGetAnAdditionalDeferConstructor() throws Exception {
+        MockClassLoader mockClassLoader = new MockClassLoader(new String[] { MockClassLoader.MODIFY_ALL_CLASSES });
+        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new MainMockTransformer()));
+        final Class<?> clazz = Class.forName(SupportClasses.SubClass.class.getName(), true, mockClassLoader);
+        assertEquals("Original number of constructoprs",
+                1, SupportClasses.SubClass.class.getConstructors().length);
+        assertEquals("Number of constructors in modified class",
+                2, clazz.getConstructors().length);
+        assertNotNull("Defer-constructor expected",
+                clazz.getConstructor(IndicateReloadClass.class));
     }
 }

--- a/core/src/test/java/org/powermock/core/transformers/impl/TestClassTransformerTest.java
+++ b/core/src/test/java/org/powermock/core/transformers/impl/TestClassTransformerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.powermock.core.transformers.impl;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.powermock.core.classloader.MockClassLoader;
+import powermock.test.support.MainMockTransformerTestSupport.SupportClasses;
+
+import org.powermock.core.IndicateReloadClass;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class TestClassTransformerTest {
+
+    @Test
+    public void subclassShouldNormallyGetPublicAdditionalDeferConstructor() throws Exception {
+        new MainMockTransformerTest()
+                .subclassShouldNormallyGetAnAdditionalDeferConstructor();
+    }
+
+    @Test
+    public void subclassTestClassShouldNotGetPublicDeferConstructor() throws Exception {
+        MockClassLoader mockClassLoader = new MockClassLoader(new String[] { MockClassLoader.MODIFY_ALL_CLASSES });
+        mockClassLoader.setMockTransformerChain(Arrays.asList(new MainMockTransformer(), TestClassTransformer
+                .forTestClass(SupportClasses.SubClass.class)
+                .removesTestMethodAnnotation(Test.class)
+                .fromAllMethodsExcept(SupportClasses.SubClass.class.getMethods()[0])));
+        final Class<?> clazz = Class.forName(SupportClasses.SubClass.class.getName(), true, mockClassLoader);
+        assertEquals("Original number of constructoprs",
+                1, SupportClasses.SubClass.class.getConstructors().length);
+        try {
+            fail("A public defer-constructor is not expected: "
+                    + clazz.getConstructor(IndicateReloadClass.class));
+        } catch (NoSuchMethodException expected) {}
+        assertEquals("Number of (public) constructors in modified class",
+                1, clazz.getConstructors().length);
+
+        assertNotNull("But there should still be a non-public defer constructor!",
+                clazz.getDeclaredConstructor(IndicateReloadClass.class));
+    }
+}

--- a/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
+++ b/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
@@ -44,6 +44,7 @@ public class MainMockTransformerTestSupport {
         }
 
         public class SubClass extends SuperClass {
+            public void dummyMethod() {}
         }
     }
 }

--- a/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
+++ b/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
@@ -39,5 +39,11 @@ public class MainMockTransformerTestSupport {
         public enum EnumClass {
             VALUE;
         }
+
+        class SuperClass {
+        }
+
+        public class SubClass extends SuperClass {
+        }
     }
 }

--- a/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/EnclosedTest.java
+++ b/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/EnclosedTest.java
@@ -75,4 +75,6 @@ public class EnclosedTest {
                     not(equalTo(stubbedReturnValue)));
         }
     }
+
+    public static class SubClass extends StubbedStaticReturnValue {}
 }

--- a/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/SubclassDelegateTest.java
+++ b/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/SubclassDelegateTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package powermock.modules.test.mockito.junit4.delegate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+/**
+ * To verify that annotation {@link PowerMockRunnerDelegate} works OK when the
+ * test-class has a super-class that will be loaded from the same class-loader.
+ * (This used to make JUnit's default runner fail with
+ * java.lang.IllegalArgumentException: Test class can only have one constructor
+ * during initialization.)
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate
+public class SubclassDelegateTest extends SuperClass {
+
+    @Test
+    public void test() {}
+}

--- a/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/SuperClass.java
+++ b/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/SuperClass.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package powermock.modules.test.mockito.junit4.delegate;
+
+class SuperClass {}


### PR DESCRIPTION
The problem can occur when @PowerMockRunnerDelegate is used and the test-class extends another class from the PowerMock classloader.
The root-cause is that the delegate-runner can be confused by the defer-constructor, which is added to the test-class by the PowerMock classloader. This pull-requests deals with the problem by making sure that test-class defer-constructors are protected (i.e. not public).