### PR TITLE
use mockito-core instead of mockito-all

### DIFF
--- a/api/mockito/pom.xml
+++ b/api/mockito/pom.xml
@@ -17,7 +17,11 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-            <version>1.10.8</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/modules/module-test/pom.xml
+++ b/modules/module-test/pom.xml
@@ -16,6 +16,15 @@
         Tests for mocking framework modules.
     </description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <modules>
         <module>easymock</module>
         <module>mockito</module>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <properties>
         <easymock.version>3.3</easymock.version>
         <mockito.version>1.10.8</mockito.version>
+        <hamcrest.version>1.1</hamcrest.version>
     </properties>
     <build>
         <plugins>
@@ -338,8 +339,13 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.objenesis</groupId>

--- a/release/with-junit-mockito-dependencies/pom.xml
+++ b/release/with-junit-mockito-dependencies/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/release/with-testng-mockito-dependencies/pom.xml
+++ b/release/with-testng-mockito-dependencies/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* why?
  * see https://github.com/mockito/mockito/wiki/Declaring-mockito-dependency
  * mockito-all is messy for Maven users as it contains the Hamcrest 1.1 and Objenesis 2.1 classes
  * mockito-core is cleaner for Maven users as it declares these as dependencies
* this change makes it much easier to use JUnit + Mockito + Powermock + Hamcrest
  * in the past the order in which the dependencies were declared was relevant
    (respectively the resulting order in the classpath)
  * now Hamcrest 1.3 instead of 1.1 can be used irrespective of the dependency order
* api/mockito requires Hamcrest to compile some classes in src/main,
  so Hamcrest has to be defined with scope 'compile' (mockito-core specifies 'runtime' only)
* using Hamcrest 1.1 as dependency for the Mockito API as Mockito uses this version
* using Hamcrest 1.3 as dependency for the tests as they use some features from this version