### PR TITLE
Fixes issue 524 : Mockito 1.10.9+ incompatibility, by repackaging CGLIB MockMaker

### DIFF
--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoMethodInvocationControl.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoMethodInvocationControl.java
@@ -20,12 +20,11 @@ import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.exceptions.misusing.NotAMockException;
 import org.mockito.internal.InternalMockHandler;
 import org.mockito.internal.creation.DelegatingMethod;
-import org.mockito.internal.creation.MethodInterceptorFilter;
 import org.mockito.internal.debugging.Localized;
 import org.mockito.internal.exceptions.stacktrace.StackTraceFilter;
 import org.mockito.internal.invocation.InvocationImpl;
 import org.mockito.internal.invocation.MatchersBinder;
-import org.mockito.internal.invocation.realmethod.FilteredCGLIBProxyRealMethod;
+import org.mockito.internal.invocation.realmethod.CleanTraceRealMethod;
 import org.mockito.internal.invocation.realmethod.RealMethod;
 import org.mockito.internal.progress.MockingProgress;
 import org.mockito.internal.progress.SequenceNumber;
@@ -37,6 +36,7 @@ import org.mockito.invocation.Invocation;
 import org.mockito.invocation.MockHandler;
 import org.mockito.verification.VerificationMode;
 import org.powermock.api.mockito.internal.verification.StaticMockAwareVerificationMode;
+import org.powermock.api.mockito.repackaged.MethodInterceptorFilter;
 import org.powermock.api.support.SafeExceptionRethrower;
 import org.powermock.core.MockGateway;
 import org.powermock.core.MockRepository;
@@ -94,8 +94,7 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
      * <code>null</code> (if it is then no calls will be forwarded to this
      * instance). If a delegator exists (i.e. not null) all non-mocked calls
      * will be delegated to that instance.
-     *
-     * @param methodInterceptionFilter
+     *  @param methodInterceptionFilter
      *            The methodInterceptionFilter to be associated with this
      *            instance.
      * @param delegator
@@ -116,7 +115,6 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
      *            The methods that are mocked for this instance. If
      *            <code>methodsToMock</code> is null or empty, all methods for
      *            the <code>invocationHandler</code> are considered to be
-     *            mocked.
      */
     public MockitoMethodInvocationControl(MethodInterceptorFilter methodInterceptionFilter, Object delegator,
                                           Object mockInstance, Method... methodsToMock) {
@@ -220,7 +218,7 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
                                     final Method method, Object[] arguments) throws Throwable {
         MockHandler mockHandler = invocationHandler.getHandler();
 
-        final FilteredCGLIBProxyRealMethod cglibProxyRealMethod = new FilteredCGLIBProxyRealMethod(new RealMethod() {
+        final CleanTraceRealMethod cglibProxyRealMethod = new CleanTraceRealMethod(new RealMethod() {
             private static final long serialVersionUID = 4564320968038564170L;
 
             public Object invoke(Object target, Object[] arguments) throws Throwable {
@@ -247,8 +245,12 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
             }
         });
 
-        Invocation invocation = new InvocationImpl(interceptionObject, new DelegatingMethod(method), arguments,
-                SequenceNumber.next(), cglibProxyRealMethod) {
+        Invocation invocation = new InvocationImpl(
+                interceptionObject,
+                new DelegatingMethod(method),
+                arguments,
+                SequenceNumber.next(),
+                cglibProxyRealMethod) {
             private static final long serialVersionUID = -3679957412502758558L;
 
             public String toString() {

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockcreation/MockCreator.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockcreation/MockCreator.java
@@ -18,13 +18,14 @@ package org.powermock.api.mockito.internal.mockcreation;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.mockito.internal.InternalMockHandler;
-import org.mockito.internal.creation.MethodInterceptorFilter;
 import org.mockito.internal.creation.MockSettingsImpl;
-import org.mockito.internal.creation.jmock.ClassImposterizer;
+import org.mockito.internal.creation.instance.InstantiatorProvider;
 import org.mockito.internal.handler.MockHandlerFactory;
 import org.mockito.internal.util.MockNameImpl;
 import org.mockito.internal.util.reflection.LenientCopyTool;
 import org.powermock.api.mockito.internal.invocation.MockitoMethodInvocationControl;
+import org.powermock.api.mockito.repackaged.ClassImposterizer;
+import org.powermock.api.mockito.repackaged.MethodInterceptorFilter;
 import org.powermock.core.ClassReplicaCreator;
 import org.powermock.core.DefaultFieldValueGenerator;
 import org.powermock.core.MockRepository;
@@ -106,9 +107,12 @@ public class MockCreator {
 
         InternalMockHandler mockHandler = new MockHandlerFactory().create(settings);
         MethodInterceptorFilter filter = new PowerMockMethodInterceptorFilter(mockHandler, settings);
-        final T mock = (T) ClassImposterizer.INSTANCE.imposterise(filter, type);
-        final MockitoMethodInvocationControl invocationControl = new MockitoMethodInvocationControl(filter,
-                isSpy && delegator == null ? new Object() : delegator, mock, methods);
+        final T mock = (T) new ClassImposterizer(new InstantiatorProvider().getInstantiator(settings)).imposterise(filter, type);
+        final MockitoMethodInvocationControl invocationControl = new MockitoMethodInvocationControl(
+                filter,
+                isSpy && delegator == null ? new Object() : delegator,
+                mock,
+                methods);
 
         return new MockData<T>(invocationControl, mock);
     }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockcreation/PowerMockMethodInterceptorFilter.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockcreation/PowerMockMethodInterceptorFilter.java
@@ -1,15 +1,11 @@
 package org.powermock.api.mockito.internal.mockcreation;
 
-import java.lang.reflect.Method;
-
 import org.mockito.cglib.proxy.MethodProxy;
 import org.mockito.internal.InternalMockHandler;
-import org.mockito.internal.configuration.GlobalConfiguration;
-import org.mockito.internal.creation.MethodInterceptorFilter;
-import org.mockito.internal.progress.ThreadSafeMockingProgress;
 import org.mockito.mock.MockCreationSettings;
-import org.powermock.api.support.ClassLoaderUtil;
-import org.powermock.reflect.Whitebox;
+import org.powermock.api.mockito.repackaged.MethodInterceptorFilter;
+
+import java.lang.reflect.Method;
 
 class PowerMockMethodInterceptorFilter extends MethodInterceptorFilter {
 
@@ -17,7 +13,7 @@ class PowerMockMethodInterceptorFilter extends MethodInterceptorFilter {
             MockCreationSettings mockSettings) {
         super(handler, mockSettings);
     }
-    
+
     @Override
     public Object intercept(Object proxy, Method method, Object[] args,
             MethodProxy methodProxy) throws Throwable {
@@ -29,5 +25,5 @@ class PowerMockMethodInterceptorFilter extends MethodInterceptorFilter {
         }
         return intercept;
     }
-    
+
 }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockmaker/PowerMockMaker.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockmaker/PowerMockMaker.java
@@ -16,7 +16,6 @@
 package org.powermock.api.mockito.internal.mockmaker;
 
 import org.mockito.internal.InternalMockHandler;
-import org.mockito.internal.creation.CglibMockMaker;
 import org.mockito.internal.creation.MockSettingsImpl;
 import org.mockito.internal.stubbing.InvocationContainer;
 import org.mockito.internal.util.MockNameImpl;
@@ -26,18 +25,21 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.MockMaker;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.VoidMethodStubbable;
+import org.powermock.api.mockito.repackaged.CglibMockMaker;
 
 import java.util.List;
 
 /**
- * A PowerMock implementation of the MockMaker. Right now it simply delegates to the
- * {@link org.mockito.internal.creation.CglibMockMaker} but in the future we may use it more properly.
- * The reason for its existence is that the CglibMockMaker throws exception for when getting the name
- * from of a mock that is created by PowerMock but not know for Mockito. This is trigged when by the MockUtil class.
+ * A PowerMock implementation of the MockMaker. Right now it simply delegates to the default Mockito
+ * {@link org.mockito.plugins.MockMaker} via {@link org.mockito.internal.configuration.plugins.Plugins#getMockMaker()}
+ * but in the future we may use it more properly.
+ * The reason for its existence is that the current Mockito MockMaker throws exception when getting the name
+ * from of a mock that is created by PowerMock but not know for Mockito. This is triggered when by the
+ * {@link org.mockito.internal.util.MockUtil} class.
  * For more details see the {@link org.powermock.api.mockito.internal.invocation.ToStringGenerator}.
  */
 public class PowerMockMaker implements MockMaker {
-    private final CglibMockMaker cglibMockMaker = new CglibMockMaker();
+    private final MockMaker cglibMockMaker = new CglibMockMaker();
 
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         return cglibMockMaker.createMock(settings, handler);

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/AcrossJVMSerializationFeature.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/AcrossJVMSerializationFeature.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.Incubating;
+import org.mockito.exceptions.base.MockitoSerializationIssue;
+import org.mockito.internal.creation.instance.InstantiatorProvider;
+import org.mockito.internal.creation.settings.CreationSettings;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.mock.MockName;
+import org.mockito.mock.SerializableMode;
+
+import java.io.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.mockito.internal.util.StringJoiner.join;
+
+/**
+ * This is responsible for serializing a mock, it is enabled if the mock is implementing
+ * {@link Serializable}.
+ *
+ * <p>
+ *     The way it works is to enable serialization via the {@link #enableSerializationAcrossJVM(MockCreationSettings)},
+ *     if the mock settings is set to be serializable it will add the {@link AcrossJVMSerializationFeature.AcrossJVMMockitoMockSerializable}
+ *     interface.
+ *     This interface defines a the {@link AcrossJVMSerializationFeature.AcrossJVMMockitoMockSerializable#writeReplace()}
+ *     whose signature match the one that is looked by the standard Java serialization.
+ * </p>
+ *
+ * <p>
+ *     Then in the {@link org.mockito.internal.creation.cglib.MethodInterceptorFilter} of mockito, if the <code>writeReplace</code> method is called,
+ *     it will use the custom implementation of this class {@link #writeReplace(Object)}. This method has a specific
+ *     knowledge on how to serialize a mockito mock that is based on CGLIB.
+ * </p>
+ *
+ * <p><strong>Only one instance per mock! See {@link org.mockito.internal.creation.cglib.MethodInterceptorFilter}</strong></p>
+ *
+ * TODO use a proper way to add the interface
+ * TODO offer a way to disable completely this behavior, or maybe enable this behavior only with a specific setting
+ * TODO check the class is mockable in the deserialization side
+ *
+ * @see org.mockito.internal.creation.cglib.CglibMockMaker
+ * @see org.mockito.internal.creation.cglib.MethodInterceptorFilter
+ * @author Brice Dutheil
+ * @since 1.10.0
+ */
+@Incubating
+class AcrossJVMSerializationFeature implements Serializable {
+    private static final long serialVersionUID = 7411152578314420778L;
+    private static final String MOCKITO_PROXY_MARKER = "MockitoProxyMarker";
+    private boolean instanceLocalCurrentlySerializingFlag = false;
+    private final Lock mutex = new ReentrantLock();
+
+    public boolean isWriteReplace(Method method) {
+        return  method.getReturnType() == Object.class
+                && method.getParameterTypes().length == 0
+                && method.getName().equals("writeReplace");
+    }
+
+
+    /**
+     * Custom implementation of the <code>writeReplace</code> method for serialization.
+     *
+     * Here's how it's working and why :
+     * <ol>
+     *     <li>
+     *         <p>When first entering in this method, it's because some is serializing the mock, with some code like :
+     * <pre class="code"><code class="java">
+     *     objectOutputStream.writeObject(mock);
+     * </code></pre>
+     *         So, {@link ObjectOutputStream} will track the <code>writeReplace</code> method in the instance and
+     *         execute it, which is wanted to replace the mock by another type that will encapsulate the actual mock.
+     *         At this point, the code will return an
+     *         {@link AcrossJVMSerializationFeature.AcrossJVMMockSerializationProxy}.</p>
+     *     </li>
+     *     <li>
+     *         <p>Now, in the constructor
+     *         {@link AcrossJVMSerializationFeature.AcrossJVMMockSerializationProxy#AcrossJVMMockSerializationProxy(Object)}
+     *         the mock is being serialized in a custom way (using
+     *         {@link AcrossJVMSerializationFeature.MockitoMockObjectOutputStream}) to a
+     *         byte array. So basically it means the code is performing double nested serialization of the passed
+     *         <code>mockitoMock</code>.</p>
+     *
+     *         <p>However the <code>ObjectOutputStream</code> will still detect the custom
+     *         <code>writeReplace</code> and execute it.
+     *         <em>(For that matter disabling replacement via {@link ObjectOutputStream#enableReplaceObject(boolean)}
+     *         doesn't disable the <code>writeReplace</code> call, but just just toggle replacement in the
+     *         written stream, <strong><code>writeReplace</code> is always called by
+     *         <code>ObjectOutputStream</code></strong>.)</em></p>
+     *
+     *         <p>In order to avoid this recursion, obviously leading to a {@link StackOverflowError}, this method is using
+     *         a flag that marks the mock as already being replaced, and then shouldn't replace itself again.
+     *         <strong>This flag is local to this class</strong>, which means the flag of this class unfortunately needs
+     *         to be protected against concurrent access, hence the reentrant lock.</p>
+     *     </li>
+     * </ol>
+     *
+     *
+     * @param mockitoMock The Mockito mock to be serialized.
+     * @return A wrapper ({@link AcrossJVMMockSerializationProxy}) to be serialized by the calling ObjectOutputStream.
+     * @throws ObjectStreamException
+     */
+    public Object writeReplace(Object mockitoMock) throws ObjectStreamException {
+        try {
+            // reentrant lock for critical section. could it be improved ?
+            mutex.lock();
+            // mark started flag // per thread, not per instance
+            // temporary loosy hack to avoid stackoverflow
+            if(mockIsCurrentlyBeingReplaced()) {
+                return mockitoMock;
+            }
+            mockReplacementStarted();
+
+            return new AcrossJVMMockSerializationProxy(mockitoMock);
+        } catch (IOException ioe) {
+            MockUtil mockUtil = new MockUtil();
+            MockName mockName = mockUtil.getMockName(mockitoMock);
+            String mockedType = mockUtil.getMockSettings(mockitoMock).getTypeToMock().getCanonicalName();
+            throw new MockitoSerializationIssue(join(
+                    "The mock '" + mockName + "' of type '" + mockedType + "'",
+                    "The Java Standard Serialization reported an '" + ioe.getClass().getSimpleName() + "' saying :",
+                    "  " + ioe.getMessage()
+            ), ioe);
+        } finally {
+            // unmark
+            mockReplacementCompleted();
+            mutex.unlock();
+        }
+    }
+
+
+    private void mockReplacementCompleted() {
+        instanceLocalCurrentlySerializingFlag = false;
+    }
+
+
+    private void mockReplacementStarted() {
+        instanceLocalCurrentlySerializingFlag = true;
+    }
+
+
+    private boolean mockIsCurrentlyBeingReplaced() {
+        return instanceLocalCurrentlySerializingFlag;
+    }
+
+
+    /**
+     * Enable serialization serialization that will work across classloaders / and JVM.
+     *
+     * <p>Only enable if settings says the mock should be serializable. In this case add the
+     * {@link AcrossJVMMockitoMockSerializable} to the extra interface list.</p>
+     *
+     * @param settings Mock creation settings.
+     * @param <T> Type param to not be bothered by the generics
+     */
+    public <T> void enableSerializationAcrossJVM(MockCreationSettings<T> settings) {
+        if (settings.getSerializableMode() == SerializableMode.ACROSS_CLASSLOADERS) {
+            // havin faith that this set is modifiable
+            // TODO use a proper way to add the interface
+            settings.getExtraInterfaces().add(AcrossJVMMockitoMockSerializable.class);
+        }
+    }
+
+
+    /**
+     * This is the serialization proxy that will encapsulate the real mock data as a byte array.
+     *
+     * <p>When called in the constructor it will serialize the mock in a byte array using a
+     * custom {@link AcrossJVMSerializationFeature.MockitoMockObjectOutputStream} that
+     * will annotate the mock class in the stream.
+     * Other information are used in this class in order to facilitate deserialization.
+     * </p>
+     *
+     * <p>Deserialization of the mock will be performed by the {@link #readResolve()} method via
+     * the custom {@link MockitoMockObjectInputStream} that will be in charge of creating the mock class.</p>
+     */
+    public static class AcrossJVMMockSerializationProxy implements Serializable {
+
+
+        private static final long serialVersionUID = -7600267929109286514L;
+        private final byte[] serializedMock;
+        private final Class typeToMock;
+        private final Set<Class> extraInterfaces;
+        /**
+         * Creates the wrapper that be used in the serialization stream.
+         *
+         * <p>Immediately serializes the Mockito mock using specifically crafted
+         * {@link AcrossJVMSerializationFeature.MockitoMockObjectOutputStream},
+         * in a byte array.</p>
+         *
+         * @param mockitoMock The Mockito mock to serialize.
+         * @throws IOException
+         */
+        public AcrossJVMMockSerializationProxy(Object mockitoMock) throws IOException {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ObjectOutputStream objectOutputStream = new MockitoMockObjectOutputStream(out);
+
+            objectOutputStream.writeObject(mockitoMock);
+
+            objectOutputStream.close();
+            out.close();
+
+            MockCreationSettings mockSettings = new MockUtil().getMockSettings(mockitoMock);
+            this.serializedMock = out.toByteArray();
+            this.typeToMock = mockSettings.getTypeToMock();
+            this.extraInterfaces = mockSettings.getExtraInterfaces();
+        }
+
+        /**
+         * Resolves the proxy to a new deserialized instance of the Mockito mock.
+         *
+         * <p>Uses the custom crafted {@link MockitoMockObjectInputStream} to deserialize the mock.</p>
+         *
+         * @return A deserialized instance of the Mockito mock.
+         * @throws ObjectStreamException
+         */
+        private Object readResolve() throws ObjectStreamException {
+            try {
+                ByteArrayInputStream bis = new ByteArrayInputStream(serializedMock);
+                ObjectInputStream objectInputStream = new MockitoMockObjectInputStream(bis, typeToMock, extraInterfaces);
+
+                Object deserializedMock = objectInputStream.readObject();
+
+                bis.close();
+                objectInputStream.close();
+
+                return deserializedMock;
+            } catch (IOException ioe) {
+                throw new MockitoSerializationIssue(join(
+                        "Mockito mock cannot be deserialized to a mock of '" + typeToMock.getCanonicalName() + "'. The error was :",
+                        "  " + ioe.getMessage(),
+                        "If you are unsure what is the reason of this exception, feel free to contact us on the mailing list."
+                ), ioe);
+            } catch (ClassNotFoundException cce) {
+                throw new MockitoSerializationIssue(join(
+                        "A class couldn't be found while deserializing a Mockito mock, you should check your classpath. The error was :",
+                        "  " + cce.getMessage(),
+                        "If you are still unsure what is the reason of this exception, feel free to contact us on the mailing list."
+                ), cce);
+            }
+        }
+    }
+
+
+    /**
+     * Special Mockito aware <code>ObjectInputStream</code> that will resolve the Mockito proxy class.
+     *
+     * <p>
+     *     This specificaly crafted ObjectInoutStream has the most important role to resolve the Mockito generated
+     *     class. It is doing so via the {@link #resolveClass(java.io.ObjectStreamClass)} which looks in the stream
+     *     for a Mockito marker. If this marker is found it will try to resolve the mockito class otherwise it
+     *     delegates class resolution to the default super behavior.
+     *     The mirror method used for serializing the mock is
+     *     {@link AcrossJVMSerializationFeature.MockitoMockObjectOutputStream#annotateClass(Class)}.
+     * </p>
+     *
+     * <p>
+     *     When this marker is found, {@link org.mockito.internal.creation.cglib.ClassImposterizer} methods are being used to create the mock class.
+     *     <em>Note that behind the <code>ClassImposterizer</code> there is CGLIB and the
+     *     {@link org.mockito.internal.creation.util.SearchingClassLoader} that will look if this enhanced class has
+     *     already been created in an accessible classloader ; so basically this code trusts the ClassImposterizer
+     *     code.</em>
+     * </p>
+     */
+    public static class MockitoMockObjectInputStream extends ObjectInputStream {
+        private final Class typeToMock;
+        private final Set<Class> extraInterfaces;
+
+        public MockitoMockObjectInputStream(InputStream in, Class typeToMock, Set<Class> extraInterfaces) throws IOException {
+            super(in) ;
+            this.typeToMock = typeToMock;
+            this.extraInterfaces = extraInterfaces;
+            enableResolveObject(true); // ensure resolving is enabled
+        }
+
+        /**
+         * Resolve the Mockito proxy class if it is marked as such.
+         *
+         * <p>Uses the fields {@link #typeToMock} and {@link #extraInterfaces} to
+         * create the Mockito proxy class as the <code>ObjectStreamClass</code>
+         * doesn't carry useful information for this purpose.</p>
+         *
+         * @param desc Description of the class in the stream, not used.
+         * @return The class that will be used to deserialize the instance mock.
+         * @throws IOException
+         * @throws ClassNotFoundException
+         */
+        @Override
+        protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+            if (notMarkedAsAMockitoMock(readObject())) {
+                return super.resolveClass(desc);
+            }
+
+            // TODO check the class is mockable in the deserialization side
+            // ClassImposterizer.INSTANCE.canImposterise(typeToMock);
+
+            // create the Mockito mock class before it can even be deserialized
+            //TODO SF unify creation of imposterizer, constructor code duplicated, pulling in CreationSettings internal class
+            ClassImposterizer imposterizer = new ClassImposterizer(new InstantiatorProvider().getInstantiator(new CreationSettings()));
+            imposterizer.setConstructorsAccessible(typeToMock, true);
+            Class<?> proxyClass = imposterizer.createProxyClass(
+                    typeToMock,
+                    extraInterfaces.toArray(new Class[extraInterfaces.size()])
+            );
+
+            hackClassNameToMatchNewlyCreatedClass(desc, proxyClass);
+
+            return proxyClass;
+
+        }
+
+        /**
+         * Hack the <code>name</code> field of the given <code>ObjectStreamClass</code> with
+         * the <code>newProxyClass</code>.
+         *
+         * The parent ObjectInputStream will check the name of the class in the stream matches the name of the one
+         * that is created in this method.
+         *
+         * The CGLIB classes uses a hash of the classloader and/or maybe some other data that allow them to be
+         * relatively unique in a JVM.
+         *
+         * When names differ, which happens when the mock is deserialized in another ClassLoader, a
+         * <code>java.io.InvalidObjectException</code> is thrown, so this part of the code is hacking through
+         * the given <code>ObjectStreamClass</code> to change the name with the newly created class.
+         *
+         * @param descInstance The <code>ObjectStreamClass</code> that will be hacked.
+         * @param proxyClass The proxy class whose name will be applied.
+         * @throws InvalidObjectException
+         */
+        private void hackClassNameToMatchNewlyCreatedClass(ObjectStreamClass descInstance, Class<?> proxyClass) throws ObjectStreamException {
+            try {
+              Field classNameField = descInstance.getClass().getDeclaredField("name");
+              new FieldSetter(descInstance, classNameField).set(proxyClass.getCanonicalName());
+            } catch (NoSuchFieldException nsfe) {
+                // TODO use our own mockito mock serialization exception
+                throw new MockitoSerializationIssue(join(
+                        "Wow, the class 'ObjectStreamClass' in the JDK don't have the field 'name',",
+                        "this is definitely a bug in our code as it means the JDK team changed a few internal things.",
+                        "",
+                        "Please report an issue with the JDK used, a code sample and a link to download the JDK would be welcome."
+                ), nsfe);
+            }
+        }
+
+        /**
+         * Read the stream class annotation and identify it as a Mockito mock or not.
+         *
+         * @param marker The marker to identify.
+         * @return <code>true</code> if not marked as a Mockito, <code>false</code> if the class annotation marks a Mockito mock.
+         * @throws IOException
+         * @throws ClassNotFoundException
+         */
+        private boolean notMarkedAsAMockitoMock(Object marker) throws IOException, ClassNotFoundException {
+            return !MOCKITO_PROXY_MARKER.equals(marker);
+        }
+    }
+
+
+    /**
+     * Special Mockito aware <code>ObjectOutputStream</code>.
+     *
+     * <p>
+     *     This output stream has the role of marking in the stream the Mockito class. This
+     *     marking process is necessary to identify the proxy class that will need to be recreated.
+     *
+     *     The mirror method used for deserializing the mock is
+     *     {@link MockitoMockObjectInputStream#resolveClass(ObjectStreamClass)}.
+     * </p>
+     *
+     */
+    private static class MockitoMockObjectOutputStream extends ObjectOutputStream {
+        private static final String NOTHING = "";
+
+        public MockitoMockObjectOutputStream(ByteArrayOutputStream out) throws IOException {
+            super(out);
+        }
+
+        /**
+         * Annotates (marks) the class if this class is a Mockito mock.
+         *
+         * @param cl The class to annotate.
+         * @throws IOException
+         */
+        @Override
+        protected void annotateClass(Class<?> cl) throws IOException {
+            writeObject(mockitoProxyClassMarker(cl));
+            // might be also useful later, for embedding classloader info ...maybe ...maybe not
+        }
+
+        /**
+         * Returns the Mockito marker if this class is a Mockito mock.
+         *
+         * @param cl The class to mark.
+         * @return The marker if this is a Mockito proxy class, otherwise returns a void marker.
+         */
+        private String mockitoProxyClassMarker(Class<?> cl) {
+            if (AcrossJVMMockitoMockSerializable.class.isAssignableFrom(cl)) {
+                return MOCKITO_PROXY_MARKER;
+            } else {
+                return NOTHING;
+            }
+        }
+    }
+
+
+    /**
+     * Simple interface that hold a correct <code>writeReplace</code> signature that can be seen by an
+     * <code>ObjectOutputStream</code>.
+     *
+     * It will be applied before the creation of the mock when the mock setting says it should serializable.
+     *
+     * @see #enableSerializationAcrossJVM(org.mockito.mock.MockCreationSettings)
+     */
+    public interface AcrossJVMMockitoMockSerializable {
+        public Object writeReplace() throws java.io.ObjectStreamException;
+    }
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/CGLIBHacker.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/CGLIBHacker.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.proxy.MethodProxy;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+
+class CGLIBHacker {
+
+    public void setMockitoNamingPolicy(MethodProxy methodProxy) {
+        try {
+            Field createInfoField = reflectOnCreateInfo(methodProxy);
+            createInfoField.setAccessible(true);
+            Object createInfo = createInfoField.get(methodProxy);
+            Field namingPolicyField = createInfo.getClass().getDeclaredField("namingPolicy");
+            namingPolicyField.setAccessible(true);
+            if (namingPolicyField.get(createInfo) == null) {
+                namingPolicyField.set(createInfo, MockitoNamingPolicy.INSTANCE);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(
+                            "Unable to set MockitoNamingPolicy on cglib generator which creates FastClasses", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Field reflectOnCreateInfo(MethodProxy methodProxy) throws SecurityException, NoSuchFieldException {
+
+        Class cglibMethodProxyClass = methodProxy.getClass();
+        // in case methodProxy was extended by user, let's traverse the object
+        // graph to find the cglib methodProxy
+        // with all the fields we would like to change
+        while (cglibMethodProxyClass != MethodProxy.class) {
+            cglibMethodProxyClass = methodProxy.getClass().getSuperclass();
+        }
+        return cglibMethodProxyClass.getDeclaredField("createInfo");
+    }
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/CglibMockMaker.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/CglibMockMaker.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.proxy.Callback;
+import org.mockito.cglib.proxy.Factory;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.InternalMockHandler;
+import org.mockito.internal.creation.instance.InstantiatorProvider;
+import org.mockito.invocation.MockHandler;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.plugins.MockMaker;
+
+/**
+ * A MockMaker that uses cglib to generate mocks on a JVM.
+ */
+public class CglibMockMaker implements MockMaker {
+
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+        InternalMockHandler mockitoHandler = cast(handler);
+        new AcrossJVMSerializationFeature().enableSerializationAcrossJVM(settings);
+        return new ClassImposterizer(new InstantiatorProvider().getInstantiator(settings)).imposterise(
+                new MethodInterceptorFilter(mockitoHandler, settings), settings.getTypeToMock(), settings.getExtraInterfaces());
+    }
+
+    private InternalMockHandler cast(MockHandler handler) {
+        if (!(handler instanceof InternalMockHandler)) {
+            throw new MockitoException("At the moment you cannot provide own implementations of MockHandler." +
+                    "\nPlease see the javadocs for the MockMaker interface.");
+        }
+        return (InternalMockHandler) handler;
+    }
+
+    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+        ((Factory) mock).setCallback(0, new MethodInterceptorFilter(cast(newHandler), settings));
+    }
+
+    public MockHandler getHandler(Object mock) {
+        if (!(mock instanceof Factory)) {
+            return null;
+        }
+        Factory factory = (Factory) mock;
+        Callback callback = factory.getCallback(0);
+        if (!(callback instanceof MethodInterceptorFilter)) {
+            return null;
+        }
+        return ((MethodInterceptorFilter) callback).getHandler();
+    }
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/ClassImposterizer.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/ClassImposterizer.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.core.CodeGenerationException;
+import org.mockito.cglib.core.NamingPolicy;
+import org.mockito.cglib.core.Predicate;
+import org.mockito.cglib.proxy.*;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.creation.instance.InstantationException;
+import org.mockito.internal.creation.instance.Instantiator;
+import org.mockito.internal.creation.util.SearchingClassLoader;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.List;
+
+import static org.mockito.internal.util.StringJoiner.join;
+
+/**
+ * Inspired on jMock (thanks jMock guys!!!)
+ */
+public class ClassImposterizer {
+
+    private final Instantiator instantiator;
+
+    public ClassImposterizer(Instantiator instantiator) {
+        this.instantiator = instantiator;
+    }
+
+    private static final NamingPolicy NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES = new MockitoNamingPolicy() {
+        @Override
+        public String getClassName(String prefix, String source, Object key, Predicate names) {
+            return "codegen." + super.getClassName(prefix, source, key, names);
+        }
+    };
+
+    private static final CallbackFilter IGNORE_BRIDGE_METHODS = new CallbackFilter() {
+        public int accept(Method method) {
+            return method.isBridge() ? 1 : 0;
+        }
+    };
+
+    public <T> T imposterise(final MethodInterceptor interceptor, Class<T> mockedType, Collection<Class> ancillaryTypes) {
+        return (T) imposterise(interceptor, mockedType, ancillaryTypes.toArray(new Class[ancillaryTypes.size()]));
+    }
+
+    public <T> T imposterise(final MethodInterceptor interceptor, Class<T> mockedType, Class<?>... ancillaryTypes) {
+        Class<Factory> proxyClass = null;
+        Object proxyInstance = null;
+        try {
+            setConstructorsAccessible(mockedType, true);
+            proxyClass = createProxyClass(mockedType, ancillaryTypes);
+            proxyInstance = createProxy(proxyClass, interceptor);
+            return mockedType.cast(proxyInstance);
+        } catch (ClassCastException cce) {
+            throw new MockitoException(join(
+                "ClassCastException occurred while creating the mockito proxy :",
+                "  class to mock : " + describeClass(mockedType),
+                "  created class : " + describeClass(proxyClass),
+                "  proxy instance class : " + describeClass(proxyInstance),
+                "  instance creation by : " + instantiator.getClass().getSimpleName(),
+                "",
+                "You might experience classloading issues, disabling the Objenesis cache *might* help (see MockitoConfiguration)"
+            ), cce);
+        } finally {
+            setConstructorsAccessible(mockedType, false);
+        }
+    }
+
+    private static String describeClass(Class type) {
+        return type == null? "null" : "'" + type.getCanonicalName() + "', loaded by classloader : '" + type.getClassLoader() + "'";
+    }
+
+    private static String describeClass(Object instance) {
+        return instance == null? "null" : describeClass(instance.getClass());
+    }
+
+    //TODO this method does not belong here
+    public void setConstructorsAccessible(Class<?> mockedType, boolean accessible) {
+        for (Constructor<?> constructor : mockedType.getDeclaredConstructors()) {
+            constructor.setAccessible(accessible);
+        }
+    }
+
+    public Class<Factory> createProxyClass(Class<?> mockedType, Class<?>... interfaces) {
+        if (mockedType == Object.class) {
+            mockedType = ClassWithSuperclassToWorkAroundCglibBug.class;
+        }
+
+        Enhancer enhancer = new Enhancer() {
+            @Override
+            @SuppressWarnings("unchecked")
+            protected void filterConstructors(Class sc, List constructors) {
+                // Don't filter
+            }
+        };
+        Class<?>[] allMockedTypes = prepend(mockedType, interfaces);
+		enhancer.setClassLoader(SearchingClassLoader.combineLoadersOf(allMockedTypes));
+        enhancer.setUseFactory(true);
+        if (mockedType.isInterface()) {
+            enhancer.setSuperclass(Object.class);
+            enhancer.setInterfaces(allMockedTypes);
+        } else {
+            enhancer.setSuperclass(mockedType);
+            enhancer.setInterfaces(interfaces);
+        }
+        enhancer.setCallbackTypes(new Class[]{MethodInterceptor.class, NoOp.class});
+        enhancer.setCallbackFilter(IGNORE_BRIDGE_METHODS);
+        if (mockedType.getSigners() != null) {
+            enhancer.setNamingPolicy(NAMING_POLICY_THAT_ALLOWS_IMPOSTERISATION_OF_CLASSES_IN_SIGNED_PACKAGES);
+        } else {
+            enhancer.setNamingPolicy(MockitoNamingPolicy.INSTANCE);
+        }
+
+        enhancer.setSerialVersionUID(42L);
+
+        try {
+            return enhancer.createClass();
+        } catch (CodeGenerationException e) {
+            if (Modifier.isPrivate(mockedType.getModifiers())) {
+                throw new MockitoException("\n"
+                        + "Mockito cannot mock this class: " + mockedType
+                        + ".\n"
+                        + "Most likely it is a private class that is not visible by Mockito");
+            }
+            throw new MockitoException("\n"
+                    + "Mockito cannot mock this class: " + mockedType
+                    + "\n"
+                    + "Mockito can only mock visible & non-final classes."
+                    + "\n"
+                    + "If you're not sure why you're getting this error, please report to the mailing list.", e);
+        }
+    }
+
+    private Object createProxy(Class<Factory> proxyClass, final MethodInterceptor interceptor) {
+        Factory proxy;
+        try {
+            proxy = instantiator.newInstance(proxyClass);
+        } catch (InstantationException e) {
+            throw new MockitoException("Unable to create mock instance of type '" + proxyClass.getSuperclass().getSimpleName() + "'", e);
+        }
+        proxy.setCallbacks(new Callback[] {interceptor, SerializableNoOp.SERIALIZABLE_INSTANCE });
+        return proxy;
+    }
+
+    private Class<?>[] prepend(Class<?> first, Class<?>... rest) {
+        Class<?>[] all = new Class<?>[rest.length+1];
+        all[0] = first;
+        System.arraycopy(rest, 0, all, 1, rest.length);
+        return all;
+    }
+
+    public static class ClassWithSuperclassToWorkAroundCglibBug {}
+
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/DelegatingMockitoMethodProxy.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/DelegatingMockitoMethodProxy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.proxy.MethodProxy;
+import org.mockito.internal.creation.util.MockitoMethodProxy;
+
+class DelegatingMockitoMethodProxy implements MockitoMethodProxy {
+
+    private final MethodProxy methodProxy;
+
+    public DelegatingMockitoMethodProxy(MethodProxy methodProxy) {
+        this.methodProxy = methodProxy;
+    }
+
+    public Object invokeSuper(Object target, Object[] arguments) throws Throwable {
+        return methodProxy.invokeSuper(target, arguments);
+    }
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/MethodInterceptorFilter.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/MethodInterceptorFilter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.proxy.MethodInterceptor;
+import org.mockito.cglib.proxy.MethodProxy;
+import org.mockito.internal.InternalMockHandler;
+import org.mockito.internal.creation.DelegatingMethod;
+import org.mockito.internal.creation.util.MockitoMethodProxy;
+import org.mockito.internal.invocation.InvocationImpl;
+import org.mockito.internal.invocation.MockitoMethod;
+import org.mockito.internal.invocation.SerializableMethod;
+import org.mockito.internal.invocation.realmethod.CleanTraceRealMethod;
+import org.mockito.internal.progress.SequenceNumber;
+import org.mockito.internal.util.ObjectMethodsGuru;
+import org.mockito.invocation.Invocation;
+import org.mockito.invocation.MockHandler;
+import org.mockito.mock.MockCreationSettings;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+/**
+ * Should be one instance per mock instance, see CglibMockMaker.
+ */
+public class MethodInterceptorFilter implements MethodInterceptor, Serializable {
+
+    private static final long serialVersionUID = 6182795666612683784L;
+    private final InternalMockHandler handler;
+    final ObjectMethodsGuru objectMethodsGuru = new ObjectMethodsGuru();
+    private final MockCreationSettings mockSettings;
+    private final AcrossJVMSerializationFeature acrossJVMSerializationFeature = new AcrossJVMSerializationFeature();
+
+    public MethodInterceptorFilter(InternalMockHandler handler, MockCreationSettings mockSettings) {
+        this.handler = handler;
+        this.mockSettings = mockSettings;
+    }
+
+    public Object intercept(Object proxy, Method method, Object[] args, MethodProxy methodProxy)
+            throws Throwable {
+        if (objectMethodsGuru.isEqualsMethod(method)) {
+            return proxy == args[0];
+        } else if (objectMethodsGuru.isHashCodeMethod(method)) {
+            return hashCodeForMock(proxy);
+        } else if (acrossJVMSerializationFeature.isWriteReplace(method)) {
+            return acrossJVMSerializationFeature.writeReplace(proxy);
+        }
+
+        MockitoMethodProxy mockitoMethodProxy = createMockitoMethodProxy(methodProxy);
+        new CGLIBHacker().setMockitoNamingPolicy(methodProxy);
+
+        MockitoMethod mockitoMethod = createMockitoMethod(method);
+
+        CleanTraceRealMethod realMethod = new CleanTraceRealMethod(mockitoMethodProxy);
+        Invocation invocation = new InvocationImpl(proxy, mockitoMethod, args, SequenceNumber.next(), realMethod);
+        return handler.handle(invocation);
+    }
+
+    public MockHandler getHandler() {
+        return handler;
+    }
+
+    private int hashCodeForMock(Object mock) {
+        return System.identityHashCode(mock);
+    }
+
+    public MockitoMethodProxy createMockitoMethodProxy(MethodProxy methodProxy) {
+        if (mockSettings.isSerializable())
+            return new SerializableMockitoMethodProxy(methodProxy);
+        return new DelegatingMockitoMethodProxy(methodProxy);
+    }
+
+    public MockitoMethod createMockitoMethod(Method method) {
+        if (mockSettings.isSerializable()) {
+            return new SerializableMethod(method);
+        } else {
+            return new DelegatingMethod(method);
+        }
+    }
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/Mockito-LICENSE.txt
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/Mockito-LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2007 Mockito contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/MockitoNamingPolicy.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/MockitoNamingPolicy.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.core.DefaultNamingPolicy;
+
+class MockitoNamingPolicy extends DefaultNamingPolicy {
+
+    public static final MockitoNamingPolicy INSTANCE = new MockitoNamingPolicy();
+
+    @Override
+    protected String getTag() {
+        return "ByMockitoWithCGLIB";
+    }
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/SerializableMockitoMethodProxy.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/SerializableMockitoMethodProxy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.proxy.MethodProxy;
+import org.mockito.internal.creation.util.MockitoMethodProxy;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import java.io.Serializable;
+
+class SerializableMockitoMethodProxy implements MockitoMethodProxy, Serializable {
+
+    private static final long serialVersionUID = -5337859962876770632L;
+    private final Class<?> c1;
+    private final Class<?> c2;
+    private final String desc;
+    private final String name;
+    private final String superName;
+    transient MethodProxy methodProxy;
+
+    public SerializableMockitoMethodProxy(MethodProxy methodProxy) {
+        assert methodProxy != null;
+        Object info = Whitebox.getInternalState(methodProxy, "createInfo");
+        c1 = (Class<?>) Whitebox.getInternalState(info, "c1");
+        c2 = (Class<?>) Whitebox.getInternalState(info, "c2");
+        desc = methodProxy.getSignature().getDescriptor();
+        name = methodProxy.getSignature().getName();
+        superName = methodProxy.getSuperName();
+        this.methodProxy = methodProxy;
+    }
+
+    private MethodProxy getMethodProxy() {
+        if (methodProxy == null) {
+            methodProxy = MethodProxy.create(c1, c2, desc, name, superName);
+        }
+        return methodProxy;
+    }
+
+    public Object invokeSuper(Object target, Object[] arguments) throws Throwable {
+        return getMethodProxy().invokeSuper(target, arguments);
+    }
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/SerializableNoOp.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/SerializableNoOp.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.powermock.api.mockito.repackaged;
+
+import org.mockito.cglib.proxy.Callback;
+import org.mockito.cglib.proxy.NoOp;
+
+import java.io.Serializable;
+
+/**
+ * Offer a Serializable implementation of the NoOp CGLIB callback.
+ */
+class SerializableNoOp implements NoOp, Serializable {
+
+    private static final long serialVersionUID = 7434976328690189159L;
+    public static final Callback SERIALIZABLE_INSTANCE = new SerializableNoOp();
+
+}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/package-info.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Mockito related CGLIB stuff. Repackaged from Mockito 1.10.19 with public visibility.
+ */
+package org.powermock.api.mockito.repackaged;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-            <version>1.10.8</version>
+            <version>1.10.19</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     </modules>
     <properties>
         <easymock.version>3.3</easymock.version>
-        <mockito.version>1.10.8</mockito.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
Fixes issue [524](https://code.google.com/p/powermock/issues/detail?id=524)

As Mockito changed the structure of this internals : renaming, package changes, visibility change, interface change. PowerMock doesn't have anymore the opportunity to hack his way by extension. 

So he best way currently is to repackage some of the mockito internals (the CGLIB related part), and change visibility where relevant. However it means that PowerMock won't use current Mockito `MockMaker`. As Mockito is progressively moving away from CGLIB, there will for sure be another implementation. Let's forget bug fixes on this front too.

A better solution has to be engineered. PR are welcome on https://github.com/mockito/mockito/