### PR TITLE
Fixes callRealMethod on static method calls

### DIFF
--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoMethodInvocationControl.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoMethodInvocationControl.java
@@ -233,7 +233,8 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
                      */
                 final Class<?> type = Whitebox.getType(interceptionObject);
                 final boolean isFinalSystemClass = type.getName().startsWith("java.") && Modifier.isFinal(type.getModifiers());
-                if (!isFinalSystemClass) {
+                final boolean isStaticMethod = interceptionObject instanceof Class<?>;
+                if (!isFinalSystemClass && !isStaticMethod) {
                     MockRepository.putAdditionalState(MockGateway.DONT_MOCK_NEXT_CALL, true);
                 }
                 try {


### PR DESCRIPTION
Please review this commit. I fixed this issue, but I don't know if it breaks something else..

https://code.google.com/p/powermock/issues/detail?id=542

New unit test to prove that non static calls are still working:

```
import android.content.Context;
import android.text.format.DateFormat;

import junit.framework.TestCase;

import org.junit.Test;
import org.junit.runner.RunWith;
import org.mockito.invocation.InvocationOnMock;
import org.mockito.stubbing.Answer;
import org.powermock.core.classloader.annotations.PrepareForTest;
import org.powermock.modules.junit4.PowerMockRunner;


import java.text.SimpleDateFormat;
import java.util.Calendar;

import static org.mockito.Matchers.any;
import static org.powermock.api.mockito.PowerMockito.mock;
import static org.powermock.api.mockito.PowerMockito.mockStatic;
import static org.powermock.api.mockito.PowerMockito.when;

/**
 * Created by Arnold Pistorius on 19-2-2015.
 */
@RunWith(PowerMockRunner.class)
@PrepareForTest({Calendar.class, DateFormat.class})
public class StaticTest extends TestCase {

    protected A aMock;

    @Override
    protected void setUp() throws Exception {
        super.setUp();

        mockStatic(DateFormat.class);
        mockStatic(Calendar.class);

        when(DateFormat.getTimeFormat(any(Context.class))).thenAnswer(new Answer<Object>() {
            @Override
            public Object answer(InvocationOnMock invocation) throws Throwable {
                return new SimpleDateFormat("hh:mm");
            }
        });

        when(Calendar.getInstance()).thenAnswer(new Answer<Object>() {
            @Override
            public Object answer(InvocationOnMock invocation) throws Throwable {
                return invocation.callRealMethod();
            }
        });


        aMock = mock(A.class);
        when(aMock.test123()).thenAnswer(new Answer<Object>() {
            @Override
            public Object answer(InvocationOnMock invocation) throws Throwable {
                return invocation.callRealMethod();
            }
        });

    }

    @Test
    public void testTest() {
        // Check if DateFormat.getTimeFormat(...) returns a SimpleDateFormat
        assertTrue(DateFormat.getTimeFormat(mock(Context.class)) instanceof SimpleDateFormat);

        assertEquals("hi!", aMock.test123());

        assertTrue(DateFormat.getTimeFormat(mock(Context.class)) instanceof SimpleDateFormat);

        // Check if Calendar.getInstance() returns a Calendar instance
        assertTrue(Calendar.getInstance() instanceof Calendar);

        // Check again if DateFormat.getTimeFormat(...) returns a SimpleDateFormat
        assertTrue(DateFormat.getTimeFormat(mock(Context.class)) instanceof SimpleDateFormat);
    }

    class A {

        public A () {}

        public String test123() {
            return "hi!";
        }
    }
}
```