### PR TITLE
Fix another "Test class can only have one constructor" issue

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.4</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/powermock/core/transformers/impl/Primitives.java
+++ b/core/src/main/java/org/powermock/core/transformers/impl/Primitives.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.powermock.core.transformers.impl;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import javassist.CtPrimitiveType;
+
+import static javassist.CtClass.*;
+
+/**
+ * Simple utility that maps constant fields of {@link javassist.CtClass} to
+ * their corresponding java class-objects for primitive types.
+ */
+class Primitives {
+
+    private static final Map<CtPrimitiveType,Class<?>> ct2primitiveClass =
+            lookupMappings();
+
+    static Class<?> getClassFor(CtPrimitiveType ctPrimitiveType) {
+        return ct2primitiveClass.get(ctPrimitiveType);
+    }
+
+    private static Map<CtPrimitiveType, Class<?>> lookupMappings() {
+        Map<CtPrimitiveType,Class<?>> mappings = new IdentityHashMap<CtPrimitiveType, Class<?>>(10);
+        for (Object[] each : new Object[][] {
+            {booleanType, boolean.class},
+            {byteType, byte.class},
+            {charType, char.class},
+            {doubleType, double.class},
+            {floatType, float.class},
+            {intType, int.class},
+            {longType, long.class},
+            {shortType, short.class},
+            {voidType, void.class}
+        }) {
+            mappings.put( (CtPrimitiveType)each[0], (Class<?>)each[1]);
+        }
+        return Collections.unmodifiableMap(mappings);
+    }
+}

--- a/core/src/main/java/org/powermock/core/transformers/impl/TestClassTransformer.java
+++ b/core/src/main/java/org/powermock/core/transformers/impl/TestClassTransformer.java
@@ -16,6 +16,7 @@
 package org.powermock.core.transformers.impl;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashSet;
@@ -23,6 +24,7 @@ import javassist.CannotCompileException;
 import javassist.CtClass;
 import javassist.CtConstructor;
 import javassist.CtMethod;
+import javassist.CtPrimitiveType;
 import javassist.Modifier;
 import javassist.NotFoundException;
 import javassist.bytecode.AnnotationsAttribute;
@@ -32,20 +34,26 @@ import org.powermock.core.transformers.MockTransformer;
 
 /**
  * MockTransformer implementation that will make PowerMock test-class
- * enhancements for three purposes...
+ * enhancements for four purposes...
  * 1) Make test-class static initializer and constructor send crucial details
  * (for PowerMockTestListener events) to GlobalNotificationBuildSupport so that
  * this information can be forwarded to whichever
  * facility is used for composing the PowerMockTestListener events.
  * 2) Removal of test-method annotations as a mean to achieve test-suite
  * chunking!
- * 3) Set test-class defer constructor (if exist) as protected instead of public.
+ * 3) Restore original test-class constructors` accesses
+ * (in case they have all been made public by {@link
+ * MainMockTransformer#setAllConstructorsToPublic(javassist.CtClass)})
+ * - to avoid that multiple <i>public</i> test-class constructors cause
+ * a delegate runner from JUnit (or 3rd party) to bail out with an
+ * error message such as "Test class can only have one constructor".
+ * 4) Set test-class defer constructor (if exist) as protected instead of public.
  * Otherwise a delegate runner from JUnit (or 3rd party) might get confused by
  * the presence of more than one test-class constructor and bail out with an
  * error message such as "Test class can only have one constructor".
  *
- * The #3 enhancement will also be enforced for the defer-constructors of
- * classes that are nested within the test-class.
+ * The #3 and #4 enhancements will also be enforced on the constructors
+ * of classes that are nested within the test-class.
  */
 public abstract class TestClassTransformer implements MockTransformer {
 
@@ -132,6 +140,27 @@ public abstract class TestClassTransformer implements MockTransformer {
                 && '$' == clazzName.charAt(testClass.getName().length());
     }
 
+    private Class<?> asOriginalClass(CtClass type) throws Exception {
+        try {
+            return type.isArray()
+                    ? Array.newInstance(asOriginalClass(type.getComponentType()), 0).getClass()
+                    : type.isPrimitive()
+                    ? Primitives.getClassFor((CtPrimitiveType) type)
+                    : Class.forName(type.getName(), true, testClass.getClassLoader());
+        } catch (Exception ex) {
+            throw new RuntimeException("Cannot resolve type: " + type, ex);
+        }
+    }
+
+    private Class<?>[] asOriginalClassParams(CtClass[] parameterTypes)
+    throws Exception {
+        final Class<?>[] classParams = new Class[parameterTypes.length];
+        for (int i = 0; i < classParams.length; ++i) {
+            classParams[i] = asOriginalClass(parameterTypes[i]);
+        }
+        return classParams;
+    }
+
     abstract boolean mustHaveTestAnnotationRemoved(CtMethod method) throws Exception;
 
     private void removeTestMethodAnnotationFrom(CtMethod m)
@@ -169,9 +198,11 @@ public abstract class TestClassTransformer implements MockTransformer {
             removeTestAnnotationsForTestMethodsThatRunOnOtherClassLoader(clazz);
             addLifeCycleNotifications(clazz);
             makeDeferConstructorNonPublic(clazz);
+            restoreOriginalConstructorsAccesses(clazz);
 
         } else if (isNestedWithinTestClass(clazz)) {
             makeDeferConstructorNonPublic(clazz);
+            restoreOriginalConstructorsAccesses(clazz);
         }
 
         return clazz;
@@ -221,6 +252,31 @@ public abstract class TestClassTransformer implements MockTransformer {
                     notificationCode,
                     asFinally/* unless there is a super-class, because of this
                               * problem: https://community.jboss.org/thread/94194*/);
+        }
+    }
+
+    private void restoreOriginalConstructorsAccesses(CtClass clazz) throws Exception {
+        Class<?> originalClass = testClass.getName().equals(clazz.getName())
+                ? testClass
+                : Class.forName(clazz.getName(), true, testClass.getClassLoader());
+        for (final CtConstructor ctConstr : clazz.getConstructors()) {
+            int ctModifiers = ctConstr.getModifiers();
+            if (false == Modifier.isPublic(ctModifiers)) {
+                /* Probably a defer-constructor */
+                continue;
+            }
+            int desiredAccessModifiers = originalClass.getDeclaredConstructor(
+                    asOriginalClassParams(ctConstr.getParameterTypes())).getModifiers();
+
+            if (Modifier.isPrivate(desiredAccessModifiers)) {
+                ctConstr.setModifiers(Modifier.setPrivate(ctModifiers));
+            } else if (Modifier.isProtected(desiredAccessModifiers)) {
+                ctConstr.setModifiers(Modifier.setProtected(ctModifiers));
+            } else if (false == Modifier.isPublic(desiredAccessModifiers)) {
+                ctConstr.setModifiers(Modifier.setPackage(ctModifiers));
+            } else {
+                /* ctConstr remains public */
+            }
         }
     }
 

--- a/core/src/test/java/org/powermock/core/transformers/impl/TestPrimitives.java
+++ b/core/src/test/java/org/powermock/core/transformers/impl/TestPrimitives.java
@@ -35,7 +35,7 @@ public class TestPrimitives {
         this.ctType = ctType;
     }
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "{0}")
     public static List<?> values() throws Exception {
         List<Object[]> valuesList = new ArrayList<Object[]>();
         for (Field f : CtClass.class.getFields()) {

--- a/core/src/test/java/org/powermock/core/transformers/impl/TestPrimitives.java
+++ b/core/src/test/java/org/powermock/core/transformers/impl/TestPrimitives.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.powermock.core.transformers.impl;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import javassist.CtClass;
+import javassist.CtPrimitiveType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class TestPrimitives {
+
+    final CtPrimitiveType ctType;
+
+    public TestPrimitives(CtPrimitiveType ctType) {
+        this.ctType = ctType;
+    }
+
+    @Parameterized.Parameters
+    public static List<?> values() throws Exception {
+        List<Object[]> valuesList = new ArrayList<Object[]>();
+        for (Field f : CtClass.class.getFields()) {
+            if (CtClass.class.isAssignableFrom(f.getType())) {
+                valuesList.add(new Object[] {f.get(null)});
+            }
+        }
+        return valuesList;
+    }
+
+    @Test
+    public void testMapping() {
+        Class<?> mapping = Primitives.getClassFor(ctType);
+        assertEquals("Mapping for ctType=" + ctType.getName(),
+                ctType.getSimpleName(), mapping.getSimpleName());
+    }
+}

--- a/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
+++ b/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
@@ -46,5 +46,14 @@ public class MainMockTransformerTestSupport {
         public class SubClass extends SuperClass {
             public void dummyMethod() {}
         }
+
+        public static class MultipleConstructors {
+
+            public MultipleConstructors() {}
+            protected MultipleConstructors(String s) {}
+            MultipleConstructors(int i) {}
+            private MultipleConstructors(Boolean[] array) {}
+            protected MultipleConstructors(int[] iarray, boolean b, String[] sarray) {}
+        }
     }
 }

--- a/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/EnclosedTest.java
+++ b/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/EnclosedTest.java
@@ -77,4 +77,11 @@ public class EnclosedTest {
     }
 
     public static class SubClass extends StubbedStaticReturnValue {}
+
+    public static class SubClassWithExtraNonPublicConstructors
+    extends StubbedStaticReturnValue {
+        public SubClassWithExtraNonPublicConstructors() {}
+        private SubClassWithExtraNonPublicConstructors(boolean arg) {}
+        protected SubClassWithExtraNonPublicConstructors(String arg) {}
+    }
 }

--- a/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/MultipleConstructorsTest.java
+++ b/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/MultipleConstructorsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package powermock.modules.test.mockito.junit4.delegate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+/**
+ * Verifies that an additional non-public constructor does not break the test-run.
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate
+public class MultipleConstructorsTest {
+
+    public MultipleConstructorsTest() {
+    }
+
+    protected MultipleConstructorsTest(String s) {
+    }
+
+    @Test
+    public void dummyTest() {}
+}


### PR DESCRIPTION
Fix "Test class can only have one constructor" issue that occurs when a JUnit or 3rd-party delegate runner (specified by a PowerMockRunnerDelegate annotation) can only deal with one public constructor.
The problem occured because the method MainMockTransformer#setAllConstructorsToPublic(javassist.CtClass) makes all constructors public. This is useful for the classes that are prepared for test - but for the actual test-class it can result in multiple public constructors that confuse the delegate runner, which fails with the message "Test class can only have one constructor".
This pull-request works around the problem by having the new method TestClassTransformer#restoreOriginalConstructorsAccesses(javassist.CtClass) reverse the "constructor-publication" on test-classes and their nested classes.