### PR TITLE
Fix NPE constructor withArguments()

### DIFF
--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/verification/DefaultConstructorArgumentsVerfication.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/verification/DefaultConstructorArgumentsVerfication.java
@@ -34,8 +34,8 @@ public class DefaultConstructorArgumentsVerfication<T> implements ConstructorArg
 
     public void withArguments(Object argument, Object... arguments) throws Exception {
         final Object[] realArguments;
-        if (argument == null && arguments.length == 0) {
-            realArguments = null;
+        if (arguments == null) {
+            realArguments = new Object[]{argument, null};
         } else {
             realArguments = new Object[arguments.length + 1];
             realArguments[0] = argument;


### PR DESCRIPTION
NPE occurs at the line below when `withArguments()` is passed just two arguments, where the first one is not null and the second one is null.
https://github.com/jayway/powermock/compare/master...occho:master#diff-cc5b1cb3f25544c6d7ad4d0ba720bf87R40

A simple test with a variable arity method.
https://gist.github.com/occho/32583fc23183e2aca6fa