### PR TITLE
Update javassist to 3.20.0-GA

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.19.0-GA</version>
+            <version>3.20.0-GA</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This version fixes an issue with java 8 default methods.