### PR TITLE
Added refreshPolicies() to MockPolicyInitializer.

### DIFF
--- a/core/src/main/java/org/powermock/tests/utils/MockPolicyInitializer.java
+++ b/core/src/main/java/org/powermock/tests/utils/MockPolicyInitializer.java
@@ -45,4 +45,15 @@ public interface MockPolicyInitializer {
 	 *         this mock policy initializer.
 	 */
 	boolean isPrepared(String fullyQualifiedClassName);
+
+	/**
+	 * Re executes the {@link MockPolicy#} of all the policies for a given class
+	 * loader. This method must be called after a call to
+	 * {@link MockPolicyInitializer#initialize(ClassLoader)} on the same class
+	 * loader.
+	 * <p>
+	 * Note that if the class-loader is not an instance of
+	 * {@link MockClassLoader} this method will return silently.
+	 */
+	void refreshPolicies(ClassLoader classLoader);
 }

--- a/core/src/main/java/org/powermock/tests/utils/impl/MockPolicyInitializerImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/MockPolicyInitializerImpl.java
@@ -15,6 +15,14 @@
  */
 package org.powermock.tests.utils.impl;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map.Entry;
+
 import org.powermock.core.MockRepository;
 import org.powermock.core.classloader.MockClassLoader;
 import org.powermock.core.classloader.annotations.MockPolicy;
@@ -25,10 +33,6 @@ import org.powermock.mockpolicies.impl.MockPolicyClassLoadingSettingsImpl;
 import org.powermock.mockpolicies.impl.MockPolicyInterceptionSettingsImpl;
 import org.powermock.reflect.Whitebox;
 import org.powermock.tests.utils.MockPolicyInitializer;
-
-import java.lang.reflect.*;
-import java.util.Arrays;
-import java.util.Map.Entry;
 
 /**
  * The default implementation of the {@link MockPolicyInitializer} interface for
@@ -69,6 +73,7 @@ public class MockPolicyInitializerImpl implements MockPolicyInitializer {
         }
     }
 
+    @Override
     public boolean isPrepared(String fullyQualifiedClassName) {
         MockPolicyClassLoadingSettings settings = getClassLoadingSettings();
         final boolean foundInSuppressStaticInitializer = Arrays.binarySearch(settings.getStaticInitializersToSuppress(), fullyQualifiedClassName) < 0;
@@ -77,6 +82,7 @@ public class MockPolicyInitializerImpl implements MockPolicyInitializer {
         return foundInSuppressStaticInitializer || foundClassesLoadedByMockClassloader;
     }
 
+    @Override
     public boolean needsInitialization() {
         MockPolicyClassLoadingSettings settings = getClassLoadingSettings();
         return settings.getStaticInitializersToSuppress().length > 0 || settings.getFullyQualifiedNamesOfClassesToLoadByMockClassloader().length > 0;
@@ -85,6 +91,7 @@ public class MockPolicyInitializerImpl implements MockPolicyInitializer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void initialize(ClassLoader classLoader) {
         if (classLoader instanceof MockClassLoader) {
             initialize((MockClassLoader) classLoader);
@@ -124,7 +131,14 @@ public class MockPolicyInitializerImpl implements MockPolicyInitializer {
             invokeInitializeInterceptionSettingsFromClassLoader(classLoader);
         }
     }
-
+    
+	@Override
+	public void refreshPolicies(ClassLoader classLoader) {
+		if (classLoader instanceof MockClassLoader) {
+			invokeInitializeInterceptionSettingsFromClassLoader((MockClassLoader) classLoader);
+		}
+	}
+    
     private void invokeInitializeInterceptionSettingsFromClassLoader(MockClassLoader classLoader) {
         try {
             final int sizeOfPolicies = mockPolicyTypes.length;
@@ -211,4 +225,5 @@ public class MockPolicyInitializerImpl implements MockPolicyInitializer {
         }
         return powerMockPolicies;
     }
+
 }

--- a/modules/module-impl/junit4-rule/src/main/java/org/powermock/modules/junit4/rule/PowerMockClassloaderExecutor.java
+++ b/modules/module-impl/junit4-rule/src/main/java/org/powermock/modules/junit4/rule/PowerMockClassloaderExecutor.java
@@ -15,23 +15,23 @@
  */
 package org.powermock.modules.junit4.rule;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.powermock.classloading.ClassloaderExecutor;
 import org.powermock.core.classloader.MockClassLoader;
 import org.powermock.core.transformers.MockTransformer;
 import org.powermock.core.transformers.impl.MainMockTransformer;
 import org.powermock.reflect.Whitebox;
 import org.powermock.reflect.proxyframework.RegisterProxyFramework;
-import org.powermock.tests.utils.impl.MockPolicyInitializerImpl;
+import org.powermock.tests.utils.MockPolicyInitializer;
 import org.powermock.tests.utils.impl.PowerMockIgnorePackagesExtractorImpl;
 import org.powermock.tests.utils.impl.PrepareForTestExtractorImpl;
 import org.powermock.tests.utils.impl.StaticConstructorSuppressExtractorImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class PowerMockClassloaderExecutor {
 
-    public static ClassloaderExecutor forClass(Class<?> testClass) {
+    public static ClassloaderExecutor forClass(Class<?> testClass, MockPolicyInitializer mockPolicyInitializer) {
         List<MockTransformer> mockTransformerChain = new ArrayList<MockTransformer>();
         final MainMockTransformer mainMockTransformer = new MainMockTransformer();
         mockTransformerChain.add(mainMockTransformer);
@@ -48,7 +48,7 @@ public class PowerMockClassloaderExecutor {
         mockLoader.addClassesToModify(testClassesExtractor.getTestClasses(testClass));
         mockLoader.addClassesToModify(staticInitializationExtractor.getTestClasses(testClass));
         registerProxyframework(mockLoader);
-        new MockPolicyInitializerImpl(testClass).initialize(mockLoader);
+        mockPolicyInitializer.initialize(mockLoader);
         return new ClassloaderExecutor(mockLoader);
     }
 

--- a/modules/module-impl/junit4-rule/src/main/java/org/powermock/modules/junit4/rule/PowerMockRule.java
+++ b/modules/module-impl/junit4-rule/src/main/java/org/powermock/modules/junit4/rule/PowerMockRule.java
@@ -21,34 +21,47 @@ import org.junit.runners.model.Statement;
 import org.powermock.api.support.SafeExceptionRethrower;
 import org.powermock.classloading.ClassloaderExecutor;
 import org.powermock.core.MockRepository;
+import org.powermock.tests.utils.MockPolicyInitializer;
+import org.powermock.tests.utils.impl.MockPolicyInitializerImpl;
 
 public class PowerMockRule implements MethodRule {
 	private static ClassloaderExecutor classloaderExecutor;
 	private static Class<?> previousTargetClass;
+	private static MockPolicyInitializer mockPolicyInitializer;
 
-	public Statement apply(Statement base, FrameworkMethod method, Object target) {
+	@Override
+	public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
 		if (classloaderExecutor == null || previousTargetClass != target.getClass()) {
-			classloaderExecutor = PowerMockClassloaderExecutor.forClass(target.getClass());
-			previousTargetClass = target.getClass();
+		    final Class<?> testClass = target.getClass();
+		    mockPolicyInitializer = new MockPolicyInitializerImpl(testClass);
+		    classloaderExecutor = PowerMockClassloaderExecutor.forClass(testClass, mockPolicyInitializer);
+		    previousTargetClass = target.getClass();
 		}
-		return new PowerMockStatement(base, classloaderExecutor);
+		return new PowerMockStatement(base, classloaderExecutor, mockPolicyInitializer);
 	}
 }
 
 class PowerMockStatement extends Statement {
 	private final Statement fNext;
 	private final ClassloaderExecutor classloaderExecutor;
+	private final MockPolicyInitializer mockPolicyInitializer;
 
-	public PowerMockStatement(Statement base, ClassloaderExecutor classloaderExecutor) {
+	public PowerMockStatement(final Statement base, final ClassloaderExecutor classloaderExecutor, final MockPolicyInitializer mockPolicyInitializer) {
 		fNext = base;
 		this.classloaderExecutor = classloaderExecutor;
+		this.mockPolicyInitializer = mockPolicyInitializer;
 	}
 
 	@Override
 	public void evaluate() throws Throwable {
 		classloaderExecutor.execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
+					// Re-executes the policy method that might initialize mocks that 
+					// were cleared after the previous statement.
+					// This fixes https://github.com/jayway/powermock/issues/581
+					mockPolicyInitializer.refreshPolicies(getClass().getClassLoader());
 					fNext.evaluate();
 				} catch (Throwable e) {
 					SafeExceptionRethrower.safeRethrow(e);

--- a/modules/module-test/mockito/junit4-rule-objenesis/src/test/java/org/powermock/example/Foo.java
+++ b/modules/module-test/mockito/junit4-rule-objenesis/src/test/java/org/powermock/example/Foo.java
@@ -1,0 +1,22 @@
+package org.powermock.example;
+
+public class Foo {
+
+	public Bar m() {
+		return new Bar(1);
+	}
+
+	public static class Bar {
+
+		private final int i;
+
+		Bar(final int i) {
+			this.i = i;
+		}
+
+		public int getI() {
+			return i;
+		}
+	}
+
+}

--- a/modules/module-test/mockito/junit4-rule-objenesis/src/test/java/org/powermock/modules/test/junit4/rule/objenesis/PowerMockRuleTest.java
+++ b/modules/module-test/mockito/junit4-rule-objenesis/src/test/java/org/powermock/modules/test/junit4/rule/objenesis/PowerMockRuleTest.java
@@ -1,0 +1,53 @@
+package org.powermock.modules.test.junit4.rule.objenesis;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.MockPolicy;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.spi.PowerMockPolicy;
+import org.powermock.example.Foo;
+import org.powermock.example.Foo.Bar;
+import org.powermock.mockpolicies.MockPolicyClassLoadingSettings;
+import org.powermock.mockpolicies.MockPolicyInterceptionSettings;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.powermock.reflect.Whitebox;
+
+@PowerMockIgnore("org.mockito.*")
+@PrepareForTest(Foo.class)
+@MockPolicy(PowerMockRuleTest.CustomPolicy.class)
+public class PowerMockRuleTest {
+
+    @Rule
+    public final PowerMockRule rule = new PowerMockRule();
+
+    @Test
+    public void test1() {
+        assertEquals(999, new Foo().m().getI());
+    }
+
+    @Test
+    public void test2() {
+        assertEquals(999, new Foo().m().getI());
+    }
+
+    public static class CustomPolicy implements PowerMockPolicy {
+
+        @Override
+        public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
+        }
+
+        @Override
+        public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
+            final Bar barMock = mock(Bar.class);
+            when(barMock.getI()).thenReturn(999);
+            settings.stubMethod(Whitebox.getMethod(Foo.class, "m"), barMock);
+        }
+    }
+
+}

--- a/modules/module-test/mockito/junit4-rule-xstream/src/test/java/org/powermock/example/Foo.java
+++ b/modules/module-test/mockito/junit4-rule-xstream/src/test/java/org/powermock/example/Foo.java
@@ -1,0 +1,22 @@
+package org.powermock.example;
+
+public class Foo {
+
+	public Bar m() {
+		return new Bar(1);
+	}
+
+	public static class Bar {
+
+		private final int i;
+
+		Bar(final int i) {
+			this.i = i;
+		}
+
+		public int getI() {
+			return i;
+		}
+	}
+
+}

--- a/modules/module-test/mockito/junit4-rule-xstream/src/test/java/org/powermock/modules/test/junit4/rule/xstream/PowerMockRuleTest.java
+++ b/modules/module-test/mockito/junit4-rule-xstream/src/test/java/org/powermock/modules/test/junit4/rule/xstream/PowerMockRuleTest.java
@@ -1,0 +1,53 @@
+package org.powermock.modules.test.junit4.rule.xstream;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.MockPolicy;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.spi.PowerMockPolicy;
+import org.powermock.example.Foo;
+import org.powermock.example.Foo.Bar;
+import org.powermock.mockpolicies.MockPolicyClassLoadingSettings;
+import org.powermock.mockpolicies.MockPolicyInterceptionSettings;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.powermock.reflect.Whitebox;
+
+@PowerMockIgnore("org.mockito.*")
+@PrepareForTest(Foo.class)
+@MockPolicy(PowerMockRuleTest.CustomPolicy.class)
+public class PowerMockRuleTest {
+
+    @Rule
+    public final PowerMockRule rule = new PowerMockRule();
+
+    @Test
+    public void test1() {
+        assertEquals(999, new Foo().m().getI());
+    }
+
+    @Test
+    public void test2() {
+        assertEquals(999, new Foo().m().getI());
+    }
+
+    public static class CustomPolicy implements PowerMockPolicy {
+
+        @Override
+        public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
+        }
+
+        @Override
+        public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
+            final Bar barMock = mock(Bar.class);
+            when(barMock.getI()).thenReturn(999);
+            settings.stubMethod(Whitebox.getMethod(Foo.class, "m"), barMock);
+        }
+    }
+
+}


### PR DESCRIPTION
This allows creating mocks in the applyInterceptionPolicy method of MockPolicy, which in turn allows using MockPolicy together with PowerMockRule.

Fixes #581