### PR TITLE
Replace usage of uberjar mockito-all with mockito-core

### DIFF
--- a/api/mockito/pom.xml
+++ b/api/mockito/pom.xml
@@ -17,7 +17,11 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/examples/byte-buddy-mockito/pom.xml
+++ b/examples/byte-buddy-mockito/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     </modules>
     <properties>
         <easymock.version>3.4</easymock.version>
+        <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
     </properties>
     <build>
@@ -327,13 +328,18 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
                 <version>2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
             </dependency>
             <dependency>
                 <groupId>cglib</groupId>

--- a/release/with-junit-mockito-dependencies/pom.xml
+++ b/release/with-junit-mockito-dependencies/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/release/with-testng-mockito-dependencies/pom.xml
+++ b/release/with-testng-mockito-dependencies/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
 * mockito-all is uberjar which bundles all transitive
   deps into single jar (hamcrest-core and objenesis). This is bad,
   becuase it disrupts Maven based dependency management. Projects
   using powermock may require different version of
   hamcrest-core than the one bundled in mockito-all. That will
   result in hamcrest-core classes being twice on classpath
   without any guarantee which one will be loaded first. That
   leads to very hard to debug issues.

 * added hamcrest-core as well as it is direct dependency