### PR TITLE
Code Quality Improvement - Constructors should only call non-overridable methods

### DIFF
--- a/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
+++ b/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
@@ -162,7 +162,7 @@ public class MockClassLoader extends DeferSupportingClassLoader {
      *                to the list of classes that will be byte-code modified to
      *                enable testability.
      */
-    public void addClassesToModify(String... classes) {
+    public final void addClassesToModify(String... classes) {
         if (classes != null) {
             for (String clazz : classes) {
                 if (!shouldDefer(packagesToBeDeferred, clazz)) {

--- a/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestSuiteChunkerImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestSuiteChunkerImpl.java
@@ -237,7 +237,7 @@ public abstract class AbstractTestSuiteChunkerImpl<T> implements TestSuiteChunke
     /**
      * {@inheritDoc}
      */
-    public void createTestDelegators(Class<?> testClass, List<TestChunk> chunks) throws Exception {
+    public final void createTestDelegators(Class<?> testClass, List<TestChunk> chunks) throws Exception {
         for (TestChunk chunk : chunks) {
             ClassLoader classLoader = chunk.getClassLoader();
             List<Method> methodsToTest = chunk.getTestMethodsToBeExecutedByThisClassloader();

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/ClassReader.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/ClassReader.java
@@ -1884,7 +1884,7 @@ public class ClassReader {
      * @param index the start index of the value to be read in {@link #b b}.
      * @return the read value.
      */
-    public int readUnsignedShort(final int index) {
+    public final int readUnsignedShort(final int index) {
         byte[] b = this.b;
         return ((b[index] & 0xFF) << 8) | (b[index + 1] & 0xFF);
     }

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/MethodWriter.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/MethodWriter.java
@@ -956,7 +956,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
-    public void visitLabel(final Label label) {
+    public final void visitLabel(final Label label) {
         // resolves previous forward references to label, if any
         resize |= label.resolve(this, code.length, code.data);
         // updates currentBlock

--- a/modules/module-impl/agent/src/main/java/sun/tools/attach/HotSpotVirtualMachine.java
+++ b/modules/module-impl/agent/src/main/java/sun/tools/attach/HotSpotVirtualMachine.java
@@ -267,7 +267,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
      * property, or the default timeout if the property is not set to a positive
      * value.
      */
-    long attachTimeout() {
+    final long attachTimeout() {
         if (attachTimeout == 0) {
             synchronized(this) {
                 if (attachTimeout == 0) {

--- a/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/NotificationBuilder.java
+++ b/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/NotificationBuilder.java
@@ -91,7 +91,7 @@ class NotificationBuilder {
             ongoingTestRuns.put(testDescription, this);            
         }
 
-        Class<?> testClass() {
+        final Class<?> testClass() {
             if (null == testClassName) {
                 return testInstance.getClass();
             } else {

--- a/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockJUnit44RunnerDelegateImpl.java
+++ b/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockJUnit44RunnerDelegateImpl.java
@@ -79,7 +79,7 @@ public class PowerMockJUnit44RunnerDelegateImpl extends Runner implements Filter
     }
 
     @SuppressWarnings("unchecked")
-    protected List<Method> getTestMethods(Class<?> klass, String[] methodsToRun) {
+    protected final List<Method> getTestMethods(Class<?> klass, String[] methodsToRun) {
         if (methodsToRun == null || methodsToRun.length == 0) {
             // The getTestMethods of TestClass is not visible so we need to look
             // it invoke it using reflection.
@@ -102,7 +102,7 @@ public class PowerMockJUnit44RunnerDelegateImpl extends Runner implements Filter
         }
     }
 
-    protected void validate() throws InitializationError {
+    protected final void validate() throws InitializationError {
         if (!TestCase.class.isAssignableFrom(testClass.getJavaClass())) {
             MethodValidator methodValidator = new PowerMockJUnit4MethodValidator(testClass);
             methodValidator.validateMethodsForDefaultRunner();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1699 - “Constructors should only call non-overridable methods”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Christian