### PR TITLE
Code Quality Improvement - @Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/api/easymock/src/main/java/org/powermock/api/easymock/PowerMock.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/PowerMock.java
@@ -1901,6 +1901,7 @@ public class PowerMock extends MemberModifier {
          * Clear the EasyMock state after the test method is executed.
          */
         MockRepository.addAfterMethodRunner(new Runnable() {
+            @Override
             public void run() {
                 LastControl.reportLastControl(null);
             }
@@ -2078,6 +2079,7 @@ public class PowerMock extends MemberModifier {
      */
     private static class EasyMockStateCleaner implements Runnable {
 
+        @Override
         public void run() {
             LastControl.reportLastControl(null);
             clearStateFromOtherClassLoaders();

--- a/api/easymock/src/main/java/org/powermock/api/easymock/internal/invocationcontrol/EasyMockMethodInvocationControl.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/internal/invocationcontrol/EasyMockMethodInvocationControl.java
@@ -83,10 +83,12 @@ public class EasyMockMethodInvocationControl<T> implements MethodInvocationContr
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isMocked(Method method) {
         return mockedMethods == null || (mockedMethods != null && mockedMethods.contains(method));
     }
 
+    @Override
     public Object invoke(Object proxy, Method method, Object[] arguments) throws Throwable {
         return invocationHandler.invoke(mockInstance == null ? proxy : mockInstance, method, arguments);
     }
@@ -114,6 +116,7 @@ public class EasyMockMethodInvocationControl<T> implements MethodInvocationContr
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Object replay(Object... mocks) {
         // Silently ignore replay if someone has replayed the mock before.
         if (!hasReplayed) {
@@ -126,6 +129,7 @@ public class EasyMockMethodInvocationControl<T> implements MethodInvocationContr
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Object verify(Object... mocks) {
         // Silently ignore verify if someone has verified the mock before.
         if (!hasVerified) {
@@ -138,6 +142,7 @@ public class EasyMockMethodInvocationControl<T> implements MethodInvocationContr
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Object reset(Object... mocks) {
         invocationHandler.getControl().reset();
         hasReplayed = false;

--- a/api/easymock/src/main/java/org/powermock/api/easymock/internal/invocationcontrol/NewInvocationControlImpl.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/internal/invocationcontrol/NewInvocationControlImpl.java
@@ -39,6 +39,7 @@ public class NewInvocationControlImpl<T> implements NewInvocationControl<IExpect
         this.substitute = substitute;
     }
 
+    @Override
     public Object invoke(Class<?> type, Object[] args, Class<?>[] sig) throws Exception {
         Constructor<?> constructor = WhiteboxImpl.getConstructor(type, sig);
         if (constructor.isVarArgs()) {
@@ -70,6 +71,7 @@ public class NewInvocationControlImpl<T> implements NewInvocationControl<IExpect
         return null;
     }
 
+    @Override
     public IExpectationSetters<T> expectSubstitutionLogic(Object... arguments) throws Exception {
         return EasyMock.expect(substitute.performSubstitutionLogic(arguments));
     }
@@ -77,6 +79,7 @@ public class NewInvocationControlImpl<T> implements NewInvocationControl<IExpect
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Object replay(Object... mocks) {
         if (!hasReplayed) {
             EasyMock.replay(substitute);
@@ -88,6 +91,7 @@ public class NewInvocationControlImpl<T> implements NewInvocationControl<IExpect
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Object verify(Object... mocks) {
         if (!hasVerified) {
             EasyMock.verify(substitute);
@@ -99,6 +103,7 @@ public class NewInvocationControlImpl<T> implements NewInvocationControl<IExpect
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Object reset(Object... mocks) {
         EasyMock.reset(substitute);
         hasReplayed = false;

--- a/api/easymock/src/main/java/org/powermock/api/easymock/internal/mockstrategy/impl/AbstractMockStrategyBase.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/internal/mockstrategy/impl/AbstractMockStrategyBase.java
@@ -20,6 +20,7 @@ public abstract class AbstractMockStrategyBase implements MockStrategy {
 		this.mockType = mockType;
 	}
 
+	@Override
 	public IMocksControl createMockControl(Class<?> type) {
 		return new MocksControl(mockType);
 	}

--- a/api/easymock/src/main/java/org/powermock/api/easymock/mockpolicies/AbstractEasyMockLogPolicyBase.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/mockpolicies/AbstractEasyMockLogPolicyBase.java
@@ -33,6 +33,7 @@ abstract class AbstractEasyMockLogPolicyBase implements PowerMockPolicy {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
 		settings.addFullyQualifiedNamesOfClassesToLoadByMockClassloader(getFullyQualifiedNamesOfClassesToLoadByMockClassloader());
 	}
@@ -40,6 +41,7 @@ abstract class AbstractEasyMockLogPolicyBase implements PowerMockPolicy {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
 		LogPolicySupport support = new LogPolicySupport();
 

--- a/api/easymock/src/main/java/org/powermock/api/easymock/mockpolicies/Log4jMockPolicy.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/mockpolicies/Log4jMockPolicy.java
@@ -35,6 +35,7 @@ public class Log4jMockPolicy extends AbstractEasyMockLogPolicyBase {
 	/**
 	 * Loads all log4j classes with the mock classloader.
 	 */
+	@Override
 	protected String[] getFullyQualifiedNamesOfClassesToLoadByMockClassloader() {
 		return new String[] { "org.apache.log4j.*" };
 	}

--- a/api/easymock/src/main/java/org/powermock/api/easymock/mockpolicies/Slf4jMockPolicy.java
+++ b/api/easymock/src/main/java/org/powermock/api/easymock/mockpolicies/Slf4jMockPolicy.java
@@ -31,6 +31,7 @@ package org.powermock.api.easymock.mockpolicies;
  */
 public class Slf4jMockPolicy extends AbstractEasyMockLogPolicyBase {
 
+	@Override
 	protected String[] getFullyQualifiedNamesOfClassesToLoadByMockClassloader() {
 		return new String[] { "org.apache.log4j.Appender", "org.slf4j.LoggerFactory", "org.apache.log4j.xml.DOMConfigurator" };
 	}

--- a/api/easymock/src/main/java/org/powermock/api/extension/proxyframework/ProxyFrameworkImpl.java
+++ b/api/easymock/src/main/java/org/powermock/api/extension/proxyframework/ProxyFrameworkImpl.java
@@ -11,6 +11,7 @@ public class ProxyFrameworkImpl implements ProxyFramework {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Class<?> getUnproxiedType(Class<?> type) {
         Class<?> currentType = type;
         while (isProxy(currentType)) {
@@ -22,6 +23,7 @@ public class ProxyFrameworkImpl implements ProxyFramework {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isProxy(Class<?> type) {
         if (type == null) {
             return false;

--- a/api/mockito/src/main/java/org/powermock/api/extension/listener/AnnotationEnabler.java
+++ b/api/mockito/src/main/java/org/powermock/api/extension/listener/AnnotationEnabler.java
@@ -111,6 +111,7 @@ public class AnnotationEnabler extends AbstractPowerMockTestListenerBase impleme
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public Class<? extends Annotation>[] getMockAnnotations() {
         return new Class[]{org.mockito.Mock.class, Mock.class, org.powermock.core.classloader.annotations.Mock.class};
     }

--- a/api/mockito/src/main/java/org/powermock/api/extension/proxyframework/ProxyFrameworkImpl.java
+++ b/api/mockito/src/main/java/org/powermock/api/extension/proxyframework/ProxyFrameworkImpl.java
@@ -27,6 +27,7 @@ public class ProxyFrameworkImpl implements ProxyFramework {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Class<?> getUnproxiedType(Class<?> type) {
         Class<?> currentType = type;
         while (isProxy(currentType)) {
@@ -43,6 +44,7 @@ public class ProxyFrameworkImpl implements ProxyFramework {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isProxy(Class<?> type) {
         if (type == null) {
             return false;

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/ConstructorAwareExpectationSetup.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/ConstructorAwareExpectationSetup.java
@@ -31,10 +31,12 @@ public class ConstructorAwareExpectationSetup<T> implements WithOrWithoutExpecte
 		this.ctor = ctor;
 	}
 
+	@Override
 	public OngoingStubbing<T> withArguments(Object firstArgument, Object... additionalArguments) throws Exception {
 		return setupExpectation().withArguments(firstArgument, additionalArguments);
 	}
 
+	@Override
 	public OngoingStubbing<T> withNoArguments() throws Exception {
 		return setupExpectation().withNoArguments();
 	}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DefaultConstructorExpectationSetup.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DefaultConstructorExpectationSetup.java
@@ -50,11 +50,13 @@ public class DefaultConstructorExpectationSetup<T> implements ConstructorExpecta
         return createNewSubstituteMock(mockType, parameterTypes, additionalArguments);
     }
 
+    @Override
     public OngoingStubbing<T> withArguments(Object firstArgument, Object... additionalArguments) throws Exception {
         return createNewSubstituteMock(mockType, parameterTypes, arrayMerger.mergeArrays(Object.class, new Object[]{firstArgument},
                 additionalArguments));
     }
 
+    @Override
     public OngoingStubbing<T> withAnyArguments() throws Exception {
         if (mockType == null) {
             throw new IllegalArgumentException("Class to expected cannot be null");
@@ -74,10 +76,12 @@ public class DefaultConstructorExpectationSetup<T> implements ConstructorExpecta
         return new DelegatingToConstructorsOngoingStubbing<T>(otherCtors, ongoingStubbing);
     }
 
+    @Override
     public OngoingStubbing<T> withNoArguments() throws Exception {
         return createNewSubstituteMock(mockType, parameterTypes, new Object[0]);
     }
 
+    @Override
     public WithExpectedArguments<T> withParameterTypes(Class<?> parameterType, Class<?>... additionalParameterTypes) {
         this.parameterTypes = arrayMerger.mergeArrays(Class.class, new Class<?>[] { parameterType }, additionalParameterTypes);
         return this;

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DefaultMethodExpectationSetup.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DefaultMethodExpectationSetup.java
@@ -39,6 +39,7 @@ public class DefaultMethodExpectationSetup<T> implements WithOrWithoutExpectedAr
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public OngoingStubbing<T> withArguments(Object firstArgument, Object... additionalArguments) throws Exception {
         if (additionalArguments == null || additionalArguments.length == 0) {
             return (OngoingStubbing<T>) Mockito.when(method.invoke(object, firstArgument));
@@ -48,6 +49,7 @@ public class DefaultMethodExpectationSetup<T> implements WithOrWithoutExpectedAr
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public OngoingStubbing<T> withNoArguments() throws Exception {
         return (OngoingStubbing<T>) Mockito.when(method.invoke(object));
     }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DefaultPrivatelyExpectedArguments.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DefaultPrivatelyExpectedArguments.java
@@ -30,6 +30,7 @@ public class DefaultPrivatelyExpectedArguments implements PrivatelyExpectedArgum
         method.setAccessible(true);
     }
 
+    @Override
     public <T> void withArguments(Object firstArgument, Object... additionalArguments) throws Exception {
         if (additionalArguments == null || additionalArguments.length == 0) {
             method.invoke(mock, firstArgument);
@@ -43,6 +44,7 @@ public class DefaultPrivatelyExpectedArguments implements PrivatelyExpectedArgum
         }
     }
 
+    @Override
     public <T> void withNoArguments() throws Exception {
         method.invoke(mock);
     }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DelegatingToConstructorsOngoingStubbing.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/DelegatingToConstructorsOngoingStubbing.java
@@ -41,6 +41,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         this.stubbing = stubbing;
     }
 
+    @Override
     public OngoingStubbing<T> thenReturn(final T value) {
         stubbing.thenReturn(value);
         return new InvokeStubMethod() {
@@ -51,6 +52,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         }.invoke();
     }
 
+    @Override
     public OngoingStubbing<T> thenReturn(final T value, final T... values) {
         stubbing.thenReturn(value, values);
         return new InvokeStubMethod() {
@@ -61,6 +63,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         }.invoke();
     }
 
+    @Override
     public OngoingStubbing<T> thenThrow(final Throwable... throwables) {
         stubbing.thenThrow(throwables);
         return new InvokeStubMethod() {
@@ -71,6 +74,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         }.invoke();
     }
 
+    @Override
     public OngoingStubbing<T> thenThrow(final Class<? extends Throwable>... throwableClasses) {
         stubbing.thenThrow(throwableClasses);
         return new InvokeStubMethod() {
@@ -81,6 +85,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         }.invoke();
     }
 
+    @Override
     public OngoingStubbing<T> thenCallRealMethod() {
         stubbing.thenCallRealMethod();
         return new InvokeStubMethod() {
@@ -91,6 +96,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         }.invoke();
     }
 
+    @Override
     public OngoingStubbing<T> thenAnswer(final Answer<?> answer) {
         stubbing.thenAnswer(answer);
         return new InvokeStubMethod() {
@@ -101,6 +107,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         }.invoke();
     }
 
+    @Override
     public OngoingStubbing<T> then(final Answer<?> answer) {
         stubbing.then(answer);
         return new InvokeStubMethod() {
@@ -111,6 +118,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
         }.invoke();
     }
 
+    @Override
     public <M> M getMock() {
         return stubbing.getMock();
     }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/PowerMockitoStubberImpl.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/expectation/PowerMockitoStubberImpl.java
@@ -36,6 +36,7 @@ public class PowerMockitoStubberImpl extends StubberImpl implements PowerMockito
     /**
      * {@inheritDoc}
      */
+    @Override
     public void when(Class<?> classMock) {
         MockitoMethodInvocationControl invocationControl = (MockitoMethodInvocationControl) MockRepository
                 .getStaticMethodInvocationControl(classMock);
@@ -73,6 +74,7 @@ public class PowerMockitoStubberImpl extends StubberImpl implements PowerMockito
         }
     }
 
+    @Override
     public <T> PrivatelyExpectedArguments when(T mock, Method method) throws Exception {
         assertNotNull(mock, "mock");
         assertNotNull(method, "Method");
@@ -80,12 +82,14 @@ public class PowerMockitoStubberImpl extends StubberImpl implements PowerMockito
         return new DefaultPrivatelyExpectedArguments(mock, method);
     }
 
+    @Override
     public <T> void when(T mock, Object... arguments) throws Exception {
         assertNotNull(mock, "mock");
         prepareForStubbing(mock);
         Whitebox.invokeMethod(mock, arguments);
     }
 
+    @Override
     public <T> void when(T mock, String methodToExpect, Object... arguments) throws Exception {
         assertNotNull(mock, "mock");
         assertNotNull(methodToExpect, "methodToExpect");
@@ -93,12 +97,14 @@ public class PowerMockitoStubberImpl extends StubberImpl implements PowerMockito
         Whitebox.invokeMethod(mock, methodToExpect, arguments);
     }
 
+    @Override
     public <T> void when(Class<T> classMock, Object... arguments) throws Exception {
         assertNotNull(classMock, "classMock");
         when(classMock);
         Whitebox.invokeMethod(classMock, arguments);
     }
 
+    @Override
     public <T> void when(Class<T> classMock, String methodToExpect, Object... parameters) throws Exception {
         assertNotNull(classMock, "classMock");
         assertNotNull(methodToExpect, "methodToExpect");
@@ -106,6 +112,7 @@ public class PowerMockitoStubberImpl extends StubberImpl implements PowerMockito
         Whitebox.invokeMethod(classMock, methodToExpect, parameters);
     }
 
+    @Override
     public <T> PrivatelyExpectedArguments when(Class<T> classMock, Method method) throws Exception {
         assertNotNull(classMock, "classMock");
         assertNotNull(method, "Method");

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoMethodInvocationControl.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoMethodInvocationControl.java
@@ -131,6 +131,7 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isMocked(Method method) {
         return mockedMethods == null || (mockedMethods != null && mockedMethods.contains(method));
     }
@@ -163,6 +164,7 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
         }
     }
 
+    @Override
     public Object invoke(final Object obj, final Method method, final Object[] arguments) throws Throwable {
         /*
            * If we come here and it means that the class has been modified by
@@ -221,6 +223,7 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
         final CleanTraceRealMethod cglibProxyRealMethod = new CleanTraceRealMethod(new RealMethod() {
             private static final long serialVersionUID = 4564320968038564170L;
 
+            @Override
             public Object invoke(Object target, Object[] arguments) throws Throwable {
                 /*
                      * Instruct the MockGateway to don't intercept the next call.
@@ -253,6 +256,7 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
                 cglibProxyRealMethod) {
             private static final long serialVersionUID = -3679957412502758558L;
 
+            @Override
             public String toString() {
                 return new ToStringGenerator().generate(getMock(), getMethod(), getArguments());
             }
@@ -282,14 +286,17 @@ public class MockitoMethodInvocationControl implements MethodInvocationControl {
         return mockHandler;
     }
 
+    @Override
     public Object replay(Object... mocks) {
         throw new IllegalStateException("Internal error: No such thing as replay exists in Mockito.");
     }
 
+    @Override
     public Object reset(Object... mocks) {
         throw new IllegalStateException("Internal error: No such thing as reset exists in Mockito.");
     }
 
+    @Override
     public Object verify(Object... mocks) {
         if (mocks == null || mocks.length != 1) {
             throw new IllegalArgumentException("Must supply one mock to the verify method.");

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoNewInvocationControl.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/invocation/MockitoNewInvocationControl.java
@@ -39,6 +39,7 @@ public class MockitoNewInvocationControl<T> implements NewInvocationControl<Ongo
 		this.substitute = substitute;
 	}
 
+	@Override
 	public Object invoke(Class<?> type, Object[] args, Class<?>[] sig) throws Exception {
 		Constructor<?> constructor = WhiteboxImpl.getConstructor(type, sig);
 		if (constructor.isVarArgs()) {
@@ -61,6 +62,7 @@ public class MockitoNewInvocationControl<T> implements NewInvocationControl<Ongo
 		return null;
 	}
 
+	@Override
 	public OngoingStubbing<T> expectSubstitutionLogic(Object... arguments) throws Exception {
 		return Mockito.when(substitute.performSubstitutionLogic(arguments));
 	}
@@ -72,6 +74,7 @@ public class MockitoNewInvocationControl<T> implements NewInvocationControl<Ongo
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public synchronized Object replay(Object... mocks) {
 		return null;
 	}
@@ -79,6 +82,7 @@ public class MockitoNewInvocationControl<T> implements NewInvocationControl<Ongo
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public synchronized Object verify(Object... mocks) {
 		final VerificationMode verificationMode;
 		Object mode = MockRepository.getAdditionalState("VerificationMode");
@@ -100,6 +104,7 @@ public class MockitoNewInvocationControl<T> implements NewInvocationControl<Ongo
 	 * {@inheritDoc}
 	 */
 	@SuppressWarnings("unchecked")
+	@Override
 	public synchronized Object reset(Object... mocks) {
 		Mockito.<InvocationSubstitute<T>> reset(substitute);
 		return null;

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockmaker/PowerMockMaker.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/mockmaker/PowerMockMaker.java
@@ -42,6 +42,7 @@ import java.util.List;
 public class PowerMockMaker implements MockMaker {
     private final MockMaker cglibMockMaker = new CglibMockMaker();
 
+    @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         T mock = cglibMockMaker.createMock(settings, handler);
         ClassLoader classLoader = cglibMockMaker.getClass().getClassLoader();
@@ -53,6 +54,7 @@ public class PowerMockMaker implements MockMaker {
         return mock;
     }
 
+    @Override
     public MockHandler getHandler(Object mock) {
         // Return a fake mock handler for static method mocks
         if (mock instanceof Class) {
@@ -62,6 +64,7 @@ public class PowerMockMaker implements MockMaker {
         }
     }
 
+    @Override
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
         cglibMockMaker.resetMock(mock, newHandler, settings);
     }
@@ -76,6 +79,7 @@ public class PowerMockMaker implements MockMaker {
             this.mock = mock;
         }
 
+        @Override
         public MockCreationSettings getMockSettings() {
             final MockSettingsImpl mockSettings = new MockSettingsImpl();
             mockSettings.setMockName(new MockNameImpl(mock.getName()));
@@ -83,17 +87,21 @@ public class PowerMockMaker implements MockMaker {
             return mockSettings;
         }
 
+        @Override
         public VoidMethodStubbable<Object> voidMethodStubbable(Object mock) {
             return null;
         }
 
+        @Override
         public void setAnswersForStubbing(List<Answer> answers) {
         }
 
+        @Override
         public InvocationContainer getInvocationContainer() {
             return null;
         }
 
+        @Override
         public Object handle(Invocation invocation) throws Throwable {
             return null;
         }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/verification/DefaultConstructorArgumentsVerfication.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/verification/DefaultConstructorArgumentsVerfication.java
@@ -32,6 +32,7 @@ public class DefaultConstructorArgumentsVerfication<T> implements ConstructorArg
         this.invocationControl = (MockitoNewInvocationControl<T>) invocationControl;
     }
 
+    @Override
     public void withArguments(Object argument, Object... arguments) throws Exception {
         final Object[] realArguments;
         if (arguments == null) {
@@ -52,6 +53,7 @@ public class DefaultConstructorArgumentsVerfication<T> implements ConstructorArg
         }
     }
 
+    @Override
     public void withNoArguments() throws Exception {
         invokeSubstitute(new Object[0]);
     }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/internal/verification/DefaultPrivateMethodVerification.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/internal/verification/DefaultPrivateMethodVerification.java
@@ -30,15 +30,18 @@ public class DefaultPrivateMethodVerification implements PrivateMethodVerificati
 		this.objectToVerify = objectToVerify;
 	}
 
+	@Override
 	public void invoke(Object... arguments) throws Exception {
 		Whitebox.invokeMethod(objectToVerify, arguments);
 
 	}
 
+	@Override
 	public void invoke(String methodToExecute, Object... arguments) throws Exception {
 		Whitebox.invokeMethod(objectToVerify, methodToExecute, (Object[]) arguments);
 	}
 
+	@Override
 	public WithOrWithoutVerifiedArguments invoke(Method method) throws Exception {
 		return new VerificationArguments(method);
 	}
@@ -54,6 +57,7 @@ public class DefaultPrivateMethodVerification implements PrivateMethodVerificati
 			this.method.setAccessible(true);
 		}
 
+		@Override
 		public void withArguments(Object firstArgument, Object... additionalArguments) throws Exception {
 			if (additionalArguments == null || additionalArguments.length == 0) {
 				method.invoke(objectToVerify, firstArgument);
@@ -63,6 +67,7 @@ public class DefaultPrivateMethodVerification implements PrivateMethodVerificati
 			}
 		}
 
+		@Override
 		public void withNoArguments() throws Exception {
 			method.invoke(objectToVerify);
 		}

--- a/api/mockito/src/main/java/org/powermock/api/mockito/mockpolicies/Slf4jMockPolicy.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/mockpolicies/Slf4jMockPolicy.java
@@ -44,6 +44,7 @@ public class Slf4jMockPolicy implements PowerMockPolicy {
 
     private static ThreadLocal<Object> threadLogger = new ThreadLocal<Object>();
 
+    @Override
     public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings mockPolicyClassLoadingSettings) {
         mockPolicyClassLoadingSettings.addFullyQualifiedNamesOfClassesToLoadByMockClassloader(
                 LOGGER_FACTORY_CLASS_NAME,
@@ -51,6 +52,7 @@ public class Slf4jMockPolicy implements PowerMockPolicy {
                 "org.apache.log4j.xml.DOMConfigurator");
     }
 
+    @Override
     public void applyInterceptionPolicy(MockPolicyInterceptionSettings mockPolicyInterceptionSettings) {
         LogPolicySupport logPolicySupport = new LogPolicySupport();
 

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/CglibMockMaker.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/CglibMockMaker.java
@@ -18,6 +18,7 @@ import org.mockito.plugins.MockMaker;
  */
 public class CglibMockMaker implements MockMaker {
 
+    @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         InternalMockHandler mockitoHandler = cast(handler);
         new AcrossJVMSerializationFeature().enableSerializationAcrossJVM(settings);
@@ -33,10 +34,12 @@ public class CglibMockMaker implements MockMaker {
         return (InternalMockHandler) handler;
     }
 
+    @Override
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
         ((Factory) mock).setCallback(0, new MethodInterceptorFilter(cast(newHandler), settings));
     }
 
+    @Override
     public MockHandler getHandler(Object mock) {
         if (!(mock instanceof Factory)) {
             return null;

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/ClassImposterizer.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/ClassImposterizer.java
@@ -40,6 +40,7 @@ public class ClassImposterizer {
     };
 
     private static final CallbackFilter IGNORE_BRIDGE_METHODS = new CallbackFilter() {
+        @Override
         public int accept(Method method) {
             return method.isBridge() ? 1 : 0;
         }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/DelegatingMockitoMethodProxy.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/DelegatingMockitoMethodProxy.java
@@ -15,6 +15,7 @@ class DelegatingMockitoMethodProxy implements MockitoMethodProxy {
         this.methodProxy = methodProxy;
     }
 
+    @Override
     public Object invokeSuper(Object target, Object[] arguments) throws Throwable {
         return methodProxy.invokeSuper(target, arguments);
     }

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/MethodInterceptorFilter.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/MethodInterceptorFilter.java
@@ -39,6 +39,7 @@ public class MethodInterceptorFilter implements MethodInterceptor, Serializable 
         this.mockSettings = mockSettings;
     }
 
+    @Override
     public Object intercept(Object proxy, Method method, Object[] args, MethodProxy methodProxy)
             throws Throwable {
         if (objectMethodsGuru.isEqualsMethod(method)) {

--- a/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/SerializableMockitoMethodProxy.java
+++ b/api/mockito/src/main/java/org/powermock/api/mockito/repackaged/SerializableMockitoMethodProxy.java
@@ -38,6 +38,7 @@ class SerializableMockitoMethodProxy implements MockitoMethodProxy, Serializable
         return methodProxy;
     }
 
+    @Override
     public Object invokeSuper(Object target, Object[] arguments) throws Throwable {
         return getMethodProxy().invokeSuper(target, arguments);
     }

--- a/api/support/src/main/java/org/powermock/api/support/membermodification/strategy/impl/MethodReplaceStrategyImpl.java
+++ b/api/support/src/main/java/org/powermock/api/support/membermodification/strategy/impl/MethodReplaceStrategyImpl.java
@@ -34,6 +34,7 @@ public class MethodReplaceStrategyImpl implements MethodReplaceStrategy {
         this.method = method;
     }
 
+    @Override
     public void with(Method method) {
         if (method == null) {
             throw new IllegalArgumentException("A metod cannot be replaced with null.");
@@ -51,6 +52,7 @@ public class MethodReplaceStrategyImpl implements MethodReplaceStrategy {
         }
     }
 
+    @Override
     public void with(InvocationHandler invocationHandler) {
         if (invocationHandler == null) {
             throw new IllegalArgumentException("Invocation handler cannot be null");
@@ -65,6 +67,7 @@ public class MethodReplaceStrategyImpl implements MethodReplaceStrategy {
             this.methodDelegator = methodDelegator;
         }
 
+        @Override
         public Object invoke(Object object, Method invokingMethod, Object[] arguments) throws Throwable {
             return methodDelegator.invoke(object, arguments);
         }

--- a/api/support/src/main/java/org/powermock/api/support/membermodification/strategy/impl/MethodStubStrategyImpl.java
+++ b/api/support/src/main/java/org/powermock/api/support/membermodification/strategy/impl/MethodStubStrategyImpl.java
@@ -34,13 +34,16 @@ public class MethodStubStrategyImpl<T> implements MethodStubStrategy<T> {
 	}
 
 	@Deprecated
+	@Override
 	public void andReturn(T returnValue) {
 		toReturn(returnValue);
 	}
 
+	@Override
 	public void toThrow(final Throwable throwable) {
 		InvocationHandler throwingInvocationHandler = new InvocationHandler() {
 
+			@Override
 			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 				throw throwable;
 			}
@@ -48,6 +51,7 @@ public class MethodStubStrategyImpl<T> implements MethodStubStrategy<T> {
 		MethodProxy.proxy(method, throwingInvocationHandler);
 	}
 
+	@Override
 	public void toReturn(T returnValue) {
 		Stubber.stubMethod(method, returnValue);
 	}

--- a/classloading/classloading-objenesis/src/main/java/org/powermock/classloading/DeepCloner.java
+++ b/classloading/classloading-objenesis/src/main/java/org/powermock/classloading/DeepCloner.java
@@ -65,6 +65,7 @@ public class DeepCloner implements DeepClonerSPI {
 	 * 
 	 * @return A deep clone of the object to clone.
 	 */
+	@Override
 	public <T> T clone(T objectToClone) {
 		return clone(objectToClone, true);
 	}

--- a/core/src/main/java/org/powermock/core/ListMap.java
+++ b/core/src/main/java/org/powermock/core/ListMap.java
@@ -31,14 +31,17 @@ public class ListMap<K, V> implements Map<K, V> {
             this.value = value;
         }
 
+        @Override
         public K getKey() {
             return key;
         }
 
+        @Override
         public V getValue() {
             return value;
         }
 
+        @Override
         public V setValue(V value) {
             V old = this.value;
             this.value = value;
@@ -47,6 +50,7 @@ public class ListMap<K, V> implements Map<K, V> {
 
     };
 
+    @Override
     public V remove(Object key) {
         for (Iterator<Map.Entry<K, V>> i = entries.iterator(); i.hasNext();) {
             Map.Entry<K, V> entry = i.next();
@@ -58,10 +62,12 @@ public class ListMap<K, V> implements Map<K, V> {
         return null;
     }
 
+    @Override
     public void clear() {
         entries.clear();
     }
 
+    @Override
     public V get(Object key) {
         for (Iterator<Map.Entry<K, V>> i = entries.iterator(); i.hasNext();) {
             Map.Entry<K, V> entry = i.next();
@@ -72,6 +78,7 @@ public class ListMap<K, V> implements Map<K, V> {
         return null;
     }
 
+    @Override
     public V put(K key, V value) {
         for (Iterator<Map.Entry<K, V>> i = entries.iterator(); i.hasNext();) {
             Map.Entry<K, V> entry = i.next();
@@ -84,10 +91,12 @@ public class ListMap<K, V> implements Map<K, V> {
         return null;
     }
 
+    @Override
     public boolean containsKey(Object key) {
         return get(key) != null;
     }
 
+    @Override
     public boolean containsValue(Object value) {
         for (Iterator<Map.Entry<K, V>> i = entries.iterator(); i.hasNext();) {
             Map.Entry<K, V> entry = i.next();
@@ -98,14 +107,17 @@ public class ListMap<K, V> implements Map<K, V> {
         return false;
     }
 
+    @Override
     public Set<java.util.Map.Entry<K, V>> entrySet() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public boolean isEmpty() {
         return entries.isEmpty();
     }
 
+    @Override
     public Set<K> keySet() {
         Set<K> identityHashSet = new HashSet<K>();
         for (Map.Entry<K, V> entry : entries) {
@@ -114,6 +126,7 @@ public class ListMap<K, V> implements Map<K, V> {
         return identityHashSet;
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public void putAll(Map<? extends K, ? extends V> t) {
         Set<?> entrySet = t.entrySet();
@@ -122,10 +135,12 @@ public class ListMap<K, V> implements Map<K, V> {
         }
     }
 
+    @Override
     public int size() {
         return entries.size();
     }
 
+    @Override
     public Collection<V> values() {
         Set<V> hashSet = new HashSet<V>();
         for (Map.Entry<K, V> entry : entries) {

--- a/core/src/main/java/org/powermock/core/classloader/DeferSupportingClassLoader.java
+++ b/core/src/main/java/org/powermock/core/classloader/DeferSupportingClassLoader.java
@@ -60,6 +60,7 @@ public abstract class DeferSupportingClassLoader extends Loader {
         this.deferPackages = deferPackages;
     }
 
+    @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
         SoftReference<Class<?>> reference = classes.get(name);
         if (reference == null || reference.get() == null) {
@@ -116,6 +117,7 @@ public abstract class DeferSupportingClassLoader extends Loader {
      * @return a <code>URL</code> for the resource, or <code>null</code> if the
      * resource could not be found.
      */
+    @Override
     protected URL findResource(String name) {
         try {
             return Whitebox.invokeMethod(deferTo, "findResource", name);
@@ -124,6 +126,7 @@ public abstract class DeferSupportingClassLoader extends Loader {
         }
     }
 
+    @Override
     protected Enumeration<URL> findResources(String name) throws IOException {
         try {
             return Whitebox.invokeMethod(deferTo, "findResources", name);
@@ -132,14 +135,17 @@ public abstract class DeferSupportingClassLoader extends Loader {
         }
     }
 
+    @Override
     public URL getResource(String s) {
         return deferTo.getResource(s);
     }
 
+    @Override
     public InputStream getResourceAsStream(String s) {
         return deferTo.getResourceAsStream(s);
     }
 
+    @Override
     public Enumeration<URL> getResources(String name) throws IOException {
         // If deferTo is already the parent, then we'd end up returning two copies of each resource...
         if (deferTo.equals(getParent()))

--- a/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
+++ b/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
@@ -172,6 +172,7 @@ public class MockClassLoader extends DeferSupportingClassLoader {
         }
     }
 
+    @Override
     protected Class<?> loadModifiedClass(String s) throws ClassFormatError, ClassNotFoundException {
         Class<?> loadedClass;
 

--- a/core/src/main/java/org/powermock/core/spi/support/AbstractPowerMockTestListenerBase.java
+++ b/core/src/main/java/org/powermock/core/spi/support/AbstractPowerMockTestListenerBase.java
@@ -31,24 +31,28 @@ public class AbstractPowerMockTestListenerBase implements PowerMockTestListener 
 	/**
 	 * Provides an empty implementation.
 	 */
+	@Override
 	public void afterTestMethod(Object testInstance, Method method, Object[] arguments, TestMethodResult testResult) throws Exception {
 	}
 
 	/**
 	 * Provides an empty implementation.
 	 */
+	@Override
 	public void beforeTestMethod(Object testInstance, Method method, Object[] arguments) throws Exception {
 	}
 
 	/**
 	 * Provides an empty implementation.
 	 */
+	@Override
 	public void beforeTestSuiteStarted(Class<?> testClass, Method[] testMethods) throws Exception {
 	}
 
 	/**
 	 * Provides an empty implementation.
 	 */
+	@Override
 	public void afterTestSuiteEnded(Class<?> testClass, Method[] methods, TestSuiteResult testResult) throws Exception {
 	}
 }

--- a/core/src/main/java/org/powermock/core/spi/testresult/impl/TestMethodResultImpl.java
+++ b/core/src/main/java/org/powermock/core/spi/testresult/impl/TestMethodResultImpl.java
@@ -27,6 +27,7 @@ public class TestMethodResultImpl implements TestMethodResult {
 		this.result = result;
 	}
 
+	@Override
 	public Result getResult() {
 		return result;
 	}

--- a/core/src/main/java/org/powermock/core/spi/testresult/impl/TestSuiteResultImpl.java
+++ b/core/src/main/java/org/powermock/core/spi/testresult/impl/TestSuiteResultImpl.java
@@ -38,18 +38,22 @@ public class TestSuiteResultImpl implements TestSuiteResult {
 		this.ignoreCount = ignoreCount;
 	}
 
+	@Override
 	public int getFailureCount() {
 		return failureCount;
 	}
 
+	@Override
 	public int getSuccessCount() {
 		return successCount;
 	}
 
+	@Override
 	public int getIgnoreCount() {
 		return ignoreCount;
 	}
 
+	@Override
 	public Result getResult() {
 		Result result = Result.SUCCESSFUL;
 		if (testCount == 0) {
@@ -60,6 +64,7 @@ public class TestSuiteResultImpl implements TestSuiteResult {
 		return result;
 	}
 
+	@Override
 	public int getTestCount() {
 		return testCount;
 	}

--- a/core/src/main/java/org/powermock/core/transformers/impl/TestClassTransformer.java
+++ b/core/src/main/java/org/powermock/core/transformers/impl/TestClassTransformer.java
@@ -71,10 +71,12 @@ public abstract class TestClassTransformer implements MockTransformer {
 
     public static ForTestClass forTestClass(final Class<?> testClass) {
         return new ForTestClass() {
+            @Override
             public RemovesTestMethodAnnotation removesTestMethodAnnotation(
                     final Class<? extends Annotation> testMethodAnnotation) {
                 return new RemovesTestMethodAnnotation() {
 
+                    @Override
                     public TestClassTransformer fromMethods(
                             final Collection<Method> testMethodsThatRunOnOtherClassLoaders) {
                         return new TestClassTransformer(testClass, testMethodAnnotation) {
@@ -101,6 +103,7 @@ public abstract class TestClassTransformer implements MockTransformer {
                         };
                     }
 
+                    @Override
                     public TestClassTransformer fromAllMethodsExcept(
                             Method singleMethodToRunOnTargetClassLoader) {
                         final String targetMethodSignature =
@@ -189,6 +192,7 @@ public abstract class TestClassTransformer implements MockTransformer {
         }
     }
 
+    @Override
     public CtClass transform(final CtClass clazz) throws Exception {
         if (clazz.isFrozen()) {
             clazz.defrost();

--- a/core/src/main/java/org/powermock/mockpolicies/impl/MockPolicyClassLoadingSettingsImpl.java
+++ b/core/src/main/java/org/powermock/mockpolicies/impl/MockPolicyClassLoadingSettingsImpl.java
@@ -33,6 +33,7 @@ public class MockPolicyClassLoadingSettingsImpl implements MockPolicyClassLoadin
 		staticInitializersToSuppress = new LinkedHashSet<String>();
 	}
 
+	@Override
 	public String[] getFullyQualifiedNamesOfClassesToLoadByMockClassloader() {
 		if (fullyQualifiedNamesOfClassesToLoadByMockClassloader == null) {
 			return new String[0];
@@ -40,6 +41,7 @@ public class MockPolicyClassLoadingSettingsImpl implements MockPolicyClassLoadin
 		return fullyQualifiedNamesOfClassesToLoadByMockClassloader.toArray(new String[fullyQualifiedNamesOfClassesToLoadByMockClassloader.size()]);
 	}
 
+	@Override
 	public String[] getStaticInitializersToSuppress() {
 		if (staticInitializersToSuppress == null) {
 			return new String[0];
@@ -47,33 +49,39 @@ public class MockPolicyClassLoadingSettingsImpl implements MockPolicyClassLoadin
 		return staticInitializersToSuppress.toArray(new String[staticInitializersToSuppress.size()]);
 	}
 
+	@Override
 	public void addFullyQualifiedNamesOfClassesToLoadByMockClassloader(String firstClass, String... additionalClasses) {
 		fullyQualifiedNamesOfClassesToLoadByMockClassloader.add(firstClass);
 		addFullyQualifiedNamesOfClassesToLoadByMockClassloader(additionalClasses);
 	}
 
+	@Override
 	public void addFullyQualifiedNamesOfClassesToLoadByMockClassloader(String[] classes) {
 		for (String clazz : classes) {
 			fullyQualifiedNamesOfClassesToLoadByMockClassloader.add(clazz);
 		}
 	}
 
+	@Override
 	public void addStaticInitializersToSuppress(String firstStaticInitializerToSuppress, String... additionalStaticInitializersToSuppress) {
 		staticInitializersToSuppress.add(firstStaticInitializerToSuppress);
 		addStaticInitializersToSuppress(additionalStaticInitializersToSuppress);
 	}
 
+	@Override
 	public void addStaticInitializersToSuppress(String[] staticInitializersToSuppress) {
 		for (String staticInitializerToSuppress : staticInitializersToSuppress) {
 			this.staticInitializersToSuppress.add(staticInitializerToSuppress);
 		}
 	}
 
+	@Override
 	public void setFullyQualifiedNamesOfClassesToLoadByMockClassloader(String[] classes) {
 		fullyQualifiedNamesOfClassesToLoadByMockClassloader.clear();
 		addFullyQualifiedNamesOfClassesToLoadByMockClassloader(classes);
 	}
 
+	@Override
 	public void setStaticInitializersToSuppress(String[] staticInitializersToSuppress) {
 		this.staticInitializersToSuppress.clear();
 		addStaticInitializersToSuppress(staticInitializersToSuppress);

--- a/core/src/main/java/org/powermock/mockpolicies/impl/MockPolicyInterceptionSettingsImpl.java
+++ b/core/src/main/java/org/powermock/mockpolicies/impl/MockPolicyInterceptionSettingsImpl.java
@@ -37,98 +37,119 @@ public class MockPolicyInterceptionSettingsImpl implements MockPolicyInterceptio
 		fieldsTypesToSuppress = new LinkedHashSet<String>();
 	}
 
+	@Override
 	public void addFieldTypesToSuppress(String firstType, String... additionalFieldTypes) {
 		fieldsTypesToSuppress.add(firstType);
 		addFieldTypesToSuppress(additionalFieldTypes);
 	}
 
+	@Override
 	public void addFieldTypesToSuppress(String[] fieldTypes) {
 		for (String fieldType : fieldTypes) {
 			fieldsTypesToSuppress.add(fieldType);
 		}
 	}
 
+	@Override
 	public void setFieldTypesToSuppress(String[] fieldTypes) {
 		fieldsTypesToSuppress.clear();
 		addFieldTypesToSuppress(fieldTypes);
 	}
 
+    @Override
 	public Field[] getFieldsToSuppress() {
 		return fieldsToSuppress.toArray(new Field[fieldsToSuppress.size()]);
 	}
 
+    @Override
 	public Method[] getMethodsToSuppress() {
 		return methodsToSuppress.toArray(new Method[methodsToSuppress.size()]);
 	}
 
+    @Override
 	public Map<Method, Object> getStubbedMethods() {
 		return Collections.unmodifiableMap(substituteReturnValues);
 	}
 
+    @Override
 	public void addFieldToSuppress(Field firstField, Field... fields) {
 		fieldsToSuppress.add(firstField);
 		addFieldToSuppress(fields);
 	}
 
+    @Override
 	public void addFieldToSuppress(Field[] fields) {
 		for (Field field : fields) {
 			fieldsToSuppress.add(field);
 		}
 	}
 
+    @Override
 	public void addMethodsToSuppress(Method methodToSuppress, Method... additionalMethodsToSuppress) {
 		methodsToSuppress.add(methodToSuppress);
 		addMethodsToSuppress(additionalMethodsToSuppress);
 	}
 
+    @Override
 	public void addMethodsToSuppress(Method[] methods) {
 		for (Method method : methods) {
 			methodsToSuppress.add(method);
 		}
 	}
 
+    @Override
 	public void stubMethod(Method method, Object returnObject) {
 		substituteReturnValues.put(method, returnObject);
 	}
 
+    @Override
 	public void setFieldsSuppress(Field[] fields) {
 		fieldsToSuppress.clear();
 		addFieldToSuppress(fields);
 	}
 
+    @Override
 	public void setMethodsToSuppress(Method[] methods) {
 		methodsToSuppress.clear();
 		addMethodsToSuppress(methods);
 	}
 
+    @Override
 	public void setMethodsToStub(Map<Method, Object> substituteReturnValues) {
 		this.substituteReturnValues = substituteReturnValues;
 	}
 
+    @Override
 	public String[] getFieldTypesToSuppress() {
 		return fieldsTypesToSuppress.toArray(new String[fieldsTypesToSuppress.size()]);
 	}
 
+    @Override
 	public void addSubtituteReturnValue(Method method, Object returnObject) {
 		substituteReturnValues.put(method, returnObject);
 	}
 
+    @Override
 	public void setSubtituteReturnValues(Map<Method, Object> substituteReturnValues) {
 		this.substituteReturnValues = substituteReturnValues;
 	}
 
+    @Override
 	public Map<Method, Object> getSubstituteReturnValues() {
 		return getStubbedMethods();
 	}
 
+    @Override
 	public Map<Method, InvocationHandler> getProxiedMethods() {
 		return proxies;
 	}
 
+    @Override
 	public void proxyMethod(Method method, InvocationHandler invocationHandler) {
 		proxies.put(method, invocationHandler);
 	}
 
+    @Override
 	public void setMethodsToProxy(Map<Method, InvocationHandler> proxies) {
 		this.proxies = proxies;
 	}

--- a/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestClassExtractor.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestClassExtractor.java
@@ -31,6 +31,7 @@ public abstract class AbstractTestClassExtractor implements TestClassesExtractor
 	 * and extracts classes that should be prepared for test in all super
 	 * classes.
 	 */
+	@Override
 	public final String[] getTestClasses(AnnotatedElement element) {
 		final Set<String> classesToPrepareForTest = new HashSet<String>();
 		if (element instanceof Class<?>) {
@@ -70,6 +71,7 @@ public abstract class AbstractTestClassExtractor implements TestClassesExtractor
 	 */
 	protected abstract String[] getClassesToModify(AnnotatedElement element);
 
+	@Override
 	public boolean isPrepared(AnnotatedElement element, String fullyQualifiedClassName) {
 		if (fullyQualifiedClassName == null) {
 			throw new IllegalArgumentException("fullyQualifiedClassName cannot be null.");

--- a/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestSuiteChunkerImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestSuiteChunkerImpl.java
@@ -206,6 +206,7 @@ public abstract class AbstractTestSuiteChunkerImpl<T> implements TestSuiteChunke
         //else{ /*Delegation-runner maybe doesn't use test-method annotations!*/ }
     }
 
+    @Override
     public ClassLoader createNewClassloader(
             Class<?> testClass,
             String[] preliminaryClassesToLoadByMockClassloader,
@@ -223,6 +224,7 @@ public abstract class AbstractTestSuiteChunkerImpl<T> implements TestSuiteChunke
             Collections.addAll(mockTransformerChain, extraMockTransformers);
             final UseClassPathAdjuster useClassPathAdjuster = testClass.getAnnotation(UseClassPathAdjuster.class);
             mockLoader = AccessController.doPrivileged(new PrivilegedAction<MockClassLoader>() {
+                @Override
                 public MockClassLoader run() {
                     return new MockClassLoader(classesToLoadByMockClassloader, packagesToIgnore, useClassPathAdjuster);
                 }
@@ -340,10 +342,12 @@ public abstract class AbstractTestSuiteChunkerImpl<T> implements TestSuiteChunke
         testAtDelegateMapper.put(internalSuites.size(), testIndexesForThisClassloader);
     }
 
+    @Override
     public int getChunkSize() {
         return getTestChunks().size();
     }
 
+    @Override
     public List<TestChunk> getTestChunks() {
         List<TestChunk> allChunks = new LinkedList<TestChunk>();
         for (TestCaseEntry entry : internalSuites) {
@@ -413,6 +417,7 @@ public abstract class AbstractTestSuiteChunkerImpl<T> implements TestSuiteChunke
     /**
      * {@inheritDoc}
      */
+    @Override
     public List<TestChunk> getTestChunksEntries(Class<?> testClass) {
         for (TestCaseEntry entry : internalSuites) {
             if (entry.getTestClass().equals(testClass)) {

--- a/core/src/main/java/org/powermock/tests/utils/impl/ArrayMergerImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/ArrayMergerImpl.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Array;
 public class ArrayMergerImpl implements ArrayMerger {
 
 	@SuppressWarnings("unchecked")
+	@Override
 	public <T> T[] mergeArrays(Class<T> type, T[]... arraysToMerge) {
 		if (arraysToMerge == null || arraysToMerge.length == 0) {
 			return (T[]) Array.newInstance(type, 0);

--- a/core/src/main/java/org/powermock/tests/utils/impl/PowerMockIgnorePackagesExtractorImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/PowerMockIgnorePackagesExtractorImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 public class PowerMockIgnorePackagesExtractorImpl implements IgnorePackagesExtractor {
 
+    @Override
     public String[] getPackagesToIgnore(AnnotatedElement element) {
         List<String> ignoredPackages = new LinkedList<String>();
         PowerMockIgnore annotation = element.getAnnotation(PowerMockIgnore.class);

--- a/core/src/main/java/org/powermock/tests/utils/impl/PowerMockTestNotifierImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/PowerMockTestNotifierImpl.java
@@ -53,6 +53,7 @@ public class PowerMockTestNotifierImpl implements PowerMockTestNotifier {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void notifyAfterTestMethod(Object testInstance, Method method, Object[] arguments, TestMethodResult testResult) {
 		for (int i = 0; i < powerMockTestListeners.length; i++) {
 			final PowerMockTestListener testListener = powerMockTestListeners[i];
@@ -67,6 +68,7 @@ public class PowerMockTestNotifierImpl implements PowerMockTestNotifier {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void notifyAfterTestSuiteEnded(Class<?> testClass, Method[] methods, TestSuiteResult testResult) {
 		for (PowerMockTestListener powerMockTestListener : powerMockTestListeners) {
 			try {
@@ -80,6 +82,7 @@ public class PowerMockTestNotifierImpl implements PowerMockTestNotifier {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void notifyBeforeTestMethod(Object testInstance, Method testMethod, Object[] arguments) {
 		MockRepository.putAdditionalState(Keys.CURRENT_TEST_INSTANCE, testInstance);
 		MockRepository.putAdditionalState(Keys.CURRENT_TEST_METHOD, testMethod);
@@ -97,6 +100,7 @@ public class PowerMockTestNotifierImpl implements PowerMockTestNotifier {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void notifyBeforeTestSuiteStarted(Class<?> testClass, Method[] testMethods) {
 		for (PowerMockTestListener powerMockTestListener : powerMockTestListeners) {
 			try {
@@ -110,6 +114,7 @@ public class PowerMockTestNotifierImpl implements PowerMockTestNotifier {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void notifyAfterTestMethod(boolean successful) {
 		final Object test = MockRepository.getAdditionalState(Keys.CURRENT_TEST_INSTANCE);
 		final Method testMethod = (Method) MockRepository.getAdditionalState(Keys.CURRENT_TEST_METHOD);

--- a/core/src/main/java/org/powermock/tests/utils/impl/TestChunkImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/TestChunkImpl.java
@@ -37,6 +37,7 @@ public class TestChunkImpl implements TestChunk {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public ClassLoader getClassLoader() {
 		return classLoader;
 	}
@@ -44,6 +45,7 @@ public class TestChunkImpl implements TestChunk {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public List<Method> getTestMethodsToBeExecutedByThisClassloader() {
 		return testMethodsToBeExecutedByThisClassloader;
 	}

--- a/examples/AbstractFactory/src/main/java/powermock/examples/service/impl/MyServiceImpl.java
+++ b/examples/AbstractFactory/src/main/java/powermock/examples/service/impl/MyServiceImpl.java
@@ -26,6 +26,7 @@ public class MyServiceImpl implements MyService {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public Set<Person> getAllPersons() {
 		return new HashSet<Person>();
 	}

--- a/examples/DocumentationExamples/src/main/java/powermock/examples/mockpolicy/policy/MyCustomMockPolicy.java
+++ b/examples/DocumentationExamples/src/main/java/powermock/examples/mockpolicy/policy/MyCustomMockPolicy.java
@@ -34,6 +34,7 @@ public class MyCustomMockPolicy implements PowerMockPolicy {
 	 * Add the {@link Dependency} to the list of classes that should be loaded
 	 * by the mock class-loader.
 	 */
+	@Override
 	public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
 		settings.addFullyQualifiedNamesOfClassesToLoadByMockClassloader(Dependency.class.getName());
 	}
@@ -42,6 +43,7 @@ public class MyCustomMockPolicy implements PowerMockPolicy {
 	 * Every time the {@link Dependency#getData()} method is invoked we return a
 	 * custom instance of a {@link DataObject}.
 	 */
+	@Override
 	public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
 		final Method getDataMethod = Whitebox.getMethod(Dependency.class);
 		final DataObject dataObject = new DataObject("Policy generated data object");

--- a/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/domainmocking/impl/SampleServiceImpl.java
+++ b/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/domainmocking/impl/SampleServiceImpl.java
@@ -50,6 +50,7 @@ public class SampleServiceImpl implements SampleService {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public boolean createPerson(String firstName, String lastName) {
 		BusinessMessages messages = new BusinessMessages();
 		Person person = null;

--- a/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/partialmocking/dao/domain/impl/ConnectionImpl.java
+++ b/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/partialmocking/dao/domain/impl/ConnectionImpl.java
@@ -19,10 +19,12 @@ import demo.org.powermock.examples.tutorial.partialmocking.dao.domain.Connection
 
 public class ConnectionImpl implements Connection {
 
+	@Override
 	public void disconnect() {
 		System.out.println("Disconnecting...");
 	}
 
+	@Override
 	public void send(byte[] data) {
 		System.out.println("Sending data of " + data.length + " bytes.");
 	}

--- a/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/partialmocking/service/impl/ProviderServiceImpl.java
+++ b/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/partialmocking/service/impl/ProviderServiceImpl.java
@@ -40,6 +40,7 @@ public class ProviderServiceImpl implements ProviderService {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public Set<ServiceProducer> getAllServiceProviders() {
 		final Set<ServiceProducer> serviceProducers = getAllServiceProducers();
 		if (serviceProducers == null) {
@@ -51,6 +52,7 @@ public class ProviderServiceImpl implements ProviderService {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public ServiceProducer getServiceProvider(int id) {
 		Set<ServiceProducer> allServiceProducers = getAllServiceProducers();
 		for (ServiceProducer serviceProducer : allServiceProducers) {

--- a/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/partialmocking/service/impl/withoutpowermock/ProviderServiceWithoutPowerMockImpl.java
+++ b/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/partialmocking/service/impl/withoutpowermock/ProviderServiceWithoutPowerMockImpl.java
@@ -54,6 +54,7 @@ public class ProviderServiceWithoutPowerMockImpl implements ProviderService {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public Set<ServiceProducer> getAllServiceProviders() {
 		final Set<ServiceProducer> serviceProducers = getAllServiceProducers();
 		if (serviceProducers == null) {
@@ -65,6 +66,7 @@ public class ProviderServiceWithoutPowerMockImpl implements ProviderService {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public ServiceProducer getServiceProvider(int id) {
 		Set<ServiceProducer> allServiceProducers = getAllServiceProducers();
 		for (ServiceProducer serviceProducer : allServiceProducers) {

--- a/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/staticmocking/impl/ServiceRegistrator.java
+++ b/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/staticmocking/impl/ServiceRegistrator.java
@@ -50,6 +50,7 @@ public class ServiceRegistrator implements IServiceRegistrator {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public long registerService(String name, Object serviceImplementation) {
 		ServiceRegistration registerService = bundleContext.registerService(name, serviceImplementation, null);
 		final long id = IdGenerator.generateNewId();
@@ -60,6 +61,7 @@ public class ServiceRegistrator implements IServiceRegistrator {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void unregisterService(long id) {
 		final ServiceRegistration registration = serviceRegistrations.remove(id);
 		if (registration == null) {

--- a/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/staticmocking/impl/withoutpowermock/ServiceRegistratorWithoutPowerMock.java
+++ b/examples/tutorial/src/main/java/demo/org/powermock/examples/tutorial/staticmocking/impl/withoutpowermock/ServiceRegistratorWithoutPowerMock.java
@@ -50,6 +50,7 @@ public class ServiceRegistratorWithoutPowerMock implements IServiceRegistrator {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public long registerService(String name, Object serviceImplementation) {
 		ServiceRegistration registerService = bundleContext.registerService(name, serviceImplementation, null);
 		final long id = generateId();
@@ -67,6 +68,7 @@ public class ServiceRegistratorWithoutPowerMock implements IServiceRegistrator {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void unregisterService(long id) {
 		final ServiceRegistration registration = serviceRegistrations.remove(id);
 		if (registration == null) {

--- a/modules/module-impl/agent/src/main/java/com/sun/tools/attach/VirtualMachine.java
+++ b/modules/module-impl/agent/src/main/java/com/sun/tools/attach/VirtualMachine.java
@@ -476,6 +476,7 @@ public abstract class VirtualMachine
     *
     * @return A hash-code value for this virtual machine
     */
+   @Override
    public int hashCode()
    {
       if (hash != 0) {
@@ -502,6 +503,7 @@ public abstract class VirtualMachine
     *         a VirtualMachine that is equal to this
     *         VirtualMachine.
     */
+   @Override
    public boolean equals(Object ob)
    {
       if (ob == this) {
@@ -520,6 +522,7 @@ public abstract class VirtualMachine
    /**
     * Returns the string representation of the <code>VirtualMachine</code>.
     */
+   @Override
    public String toString()
    {
       return provider.toString() + ": " + id;

--- a/modules/module-impl/agent/src/main/java/com/sun/tools/attach/VirtualMachineDescriptor.java
+++ b/modules/module-impl/agent/src/main/java/com/sun/tools/attach/VirtualMachineDescriptor.java
@@ -150,6 +150,7 @@ public final class VirtualMachineDescriptor
     *
     * @return A hash-code value for this descriptor.
     */
+   @Override
    public int hashCode()
    {
       if (hash != 0) {
@@ -176,6 +177,7 @@ public final class VirtualMachineDescriptor
     *         a VirtualMachineDescriptor that is equal to this
     *         VirtualMachineDescriptor.
     */
+   @Override
    public boolean equals(Object ob)
    {
       if (ob == this)
@@ -195,6 +197,7 @@ public final class VirtualMachineDescriptor
    /**
     * Returns the string representation of the <code>VirtualMachineDescriptor</code>.
     */
+   @Override
    public String toString()
    {
       String s = provider.toString() + ": " + id;

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/AnnotationWriter.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/AnnotationWriter.java
@@ -115,6 +115,7 @@ final class AnnotationWriter implements AnnotationVisitor {
     // Implementation of the AnnotationVisitor interface
     // ------------------------------------------------------------------------
 
+    @Override
     public void visit(final String name, final Object value) {
         ++size;
         if (named) {
@@ -187,6 +188,7 @@ final class AnnotationWriter implements AnnotationVisitor {
         }
     }
 
+    @Override
     public void visitEnum(
         final String name,
         final String desc,
@@ -199,6 +201,7 @@ final class AnnotationWriter implements AnnotationVisitor {
         bv.put12('e', cw.newUTF8(desc)).putShort(cw.newUTF8(value));
     }
 
+    @Override
     public AnnotationVisitor visitAnnotation(
         final String name,
         final String desc)
@@ -212,6 +215,7 @@ final class AnnotationWriter implements AnnotationVisitor {
         return new AnnotationWriter(cw, true, bv, bv, bv.length - 2);
     }
 
+    @Override
     public AnnotationVisitor visitArray(final String name) {
         ++size;
         if (named) {
@@ -222,6 +226,7 @@ final class AnnotationWriter implements AnnotationVisitor {
         return new AnnotationWriter(cw, false, bv, bv, bv.length - 2);
     }
 
+    @Override
     public void visitEnd() {
         if (parent != null) {
             byte[] data = parent.data;

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/ClassAdapter.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/ClassAdapter.java
@@ -52,6 +52,7 @@ public class ClassAdapter implements ClassVisitor {
         this.cv = cv;
     }
 
+    @Override
     public void visit(
         final int version,
         final int access,
@@ -63,10 +64,12 @@ public class ClassAdapter implements ClassVisitor {
         cv.visit(version, access, name, signature, superName, interfaces);
     }
 
+    @Override
     public void visitSource(final String source, final String debug) {
         cv.visitSource(source, debug);
     }
 
+    @Override
     public void visitOuterClass(
         final String owner,
         final String name,
@@ -75,6 +78,7 @@ public class ClassAdapter implements ClassVisitor {
         cv.visitOuterClass(owner, name, desc);
     }
 
+    @Override
     public AnnotationVisitor visitAnnotation(
         final String desc,
         final boolean visible)
@@ -82,10 +86,12 @@ public class ClassAdapter implements ClassVisitor {
         return cv.visitAnnotation(desc, visible);
     }
 
+    @Override
     public void visitAttribute(final Attribute attr) {
         cv.visitAttribute(attr);
     }
 
+    @Override
     public void visitInnerClass(
         final String name,
         final String outerName,
@@ -95,6 +101,7 @@ public class ClassAdapter implements ClassVisitor {
         cv.visitInnerClass(name, outerName, innerName, access);
     }
 
+    @Override
     public FieldVisitor visitField(
         final int access,
         final String name,
@@ -105,6 +112,7 @@ public class ClassAdapter implements ClassVisitor {
         return cv.visitField(access, name, desc, signature, value);
     }
 
+    @Override
     public MethodVisitor visitMethod(
         final int access,
         final String name,
@@ -115,6 +123,7 @@ public class ClassAdapter implements ClassVisitor {
         return cv.visitMethod(access, name, desc, signature, exceptions);
     }
 
+    @Override
     public void visitEnd() {
         cv.visitEnd();
     }

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/ClassWriter.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/ClassWriter.java
@@ -587,6 +587,7 @@ public class ClassWriter implements ClassVisitor {
     // Implementation of the ClassVisitor interface
     // ------------------------------------------------------------------------
 
+    @Override
     public void visit(
         final int version,
         final int access,
@@ -612,6 +613,7 @@ public class ClassWriter implements ClassVisitor {
         }
     }
 
+    @Override
     public void visitSource(final String file, final String debug) {
         if (file != null) {
             sourceFile = newUTF8(file);
@@ -621,6 +623,7 @@ public class ClassWriter implements ClassVisitor {
         }
     }
 
+    @Override
     public void visitOuterClass(
         final String owner,
         final String name,
@@ -632,6 +635,7 @@ public class ClassWriter implements ClassVisitor {
         }
     }
 
+    @Override
     public AnnotationVisitor visitAnnotation(
         final String desc,
         final boolean visible)
@@ -653,11 +657,13 @@ public class ClassWriter implements ClassVisitor {
         return aw;
     }
 
+    @Override
     public void visitAttribute(final Attribute attr) {
         attr.next = attrs;
         attrs = attr;
     }
 
+    @Override
     public void visitInnerClass(
         final String name,
         final String outerName,
@@ -674,6 +680,7 @@ public class ClassWriter implements ClassVisitor {
         innerClasses.putShort(access);
     }
 
+    @Override
     public FieldVisitor visitField(
         final int access,
         final String name,
@@ -684,6 +691,7 @@ public class ClassWriter implements ClassVisitor {
         return new FieldWriter(this, access, name, desc, signature, value);
     }
 
+    @Override
     public MethodVisitor visitMethod(
         final int access,
         final String name,
@@ -701,6 +709,7 @@ public class ClassWriter implements ClassVisitor {
                 computeFrames);
     }
 
+    @Override
     public void visitEnd() {
     }
 

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/FieldWriter.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/FieldWriter.java
@@ -134,6 +134,7 @@ final class FieldWriter implements FieldVisitor {
     // Implementation of the FieldVisitor interface
     // ------------------------------------------------------------------------
 
+    @Override
     public AnnotationVisitor visitAnnotation(
         final String desc,
         final boolean visible)
@@ -155,11 +156,13 @@ final class FieldWriter implements FieldVisitor {
         return aw;
     }
 
+    @Override
     public void visitAttribute(final Attribute attr) {
         attr.next = attrs;
         attrs = attr;
     }
 
+    @Override
     public void visitEnd() {
     }
 

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/Label.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/Label.java
@@ -548,6 +548,7 @@ public class Label {
      * 
      * @return a string representation of this label.
      */
+    @Override
     public String toString() {
         return "L" + System.identityHashCode(this);
     }

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/MethodAdapter.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/MethodAdapter.java
@@ -53,10 +53,12 @@ public class MethodAdapter implements MethodVisitor {
         this.mv = mv;
     }
 
+    @Override
     public AnnotationVisitor visitAnnotationDefault() {
         return mv.visitAnnotationDefault();
     }
 
+    @Override
     public AnnotationVisitor visitAnnotation(
         final String desc,
         final boolean visible)
@@ -64,6 +66,7 @@ public class MethodAdapter implements MethodVisitor {
         return mv.visitAnnotation(desc, visible);
     }
 
+    @Override
     public AnnotationVisitor visitParameterAnnotation(
         final int parameter,
         final String desc,
@@ -72,14 +75,17 @@ public class MethodAdapter implements MethodVisitor {
         return mv.visitParameterAnnotation(parameter, desc, visible);
     }
 
+    @Override
     public void visitAttribute(final Attribute attr) {
         mv.visitAttribute(attr);
     }
 
+    @Override
     public void visitCode() {
         mv.visitCode();
     }
 
+    @Override
     public void visitFrame(
         final int type,
         final int nLocal,
@@ -90,22 +96,27 @@ public class MethodAdapter implements MethodVisitor {
         mv.visitFrame(type, nLocal, local, nStack, stack);
     }
 
+    @Override
     public void visitInsn(final int opcode) {
         mv.visitInsn(opcode);
     }
 
+    @Override
     public void visitIntInsn(final int opcode, final int operand) {
         mv.visitIntInsn(opcode, operand);
     }
 
+    @Override
     public void visitVarInsn(final int opcode, final int var) {
         mv.visitVarInsn(opcode, var);
     }
 
+    @Override
     public void visitTypeInsn(final int opcode, final String type) {
         mv.visitTypeInsn(opcode, type);
     }
 
+    @Override
     public void visitFieldInsn(
         final int opcode,
         final String owner,
@@ -115,6 +126,7 @@ public class MethodAdapter implements MethodVisitor {
         mv.visitFieldInsn(opcode, owner, name, desc);
     }
 
+    @Override
     public void visitMethodInsn(
         final int opcode,
         final String owner,
@@ -124,22 +136,27 @@ public class MethodAdapter implements MethodVisitor {
         mv.visitMethodInsn(opcode, owner, name, desc);
     }
 
+    @Override
     public void visitJumpInsn(final int opcode, final Label label) {
         mv.visitJumpInsn(opcode, label);
     }
 
+    @Override
     public void visitLabel(final Label label) {
         mv.visitLabel(label);
     }
 
+    @Override
     public void visitLdcInsn(final Object cst) {
         mv.visitLdcInsn(cst);
     }
 
+    @Override
     public void visitIincInsn(final int var, final int increment) {
         mv.visitIincInsn(var, increment);
     }
 
+    @Override
     public void visitTableSwitchInsn(
         final int min,
         final int max,
@@ -149,6 +166,7 @@ public class MethodAdapter implements MethodVisitor {
         mv.visitTableSwitchInsn(min, max, dflt, labels);
     }
 
+    @Override
     public void visitLookupSwitchInsn(
         final Label dflt,
         final int[] keys,
@@ -157,10 +175,12 @@ public class MethodAdapter implements MethodVisitor {
         mv.visitLookupSwitchInsn(dflt, keys, labels);
     }
 
+    @Override
     public void visitMultiANewArrayInsn(final String desc, final int dims) {
         mv.visitMultiANewArrayInsn(desc, dims);
     }
 
+    @Override
     public void visitTryCatchBlock(
         final Label start,
         final Label end,
@@ -170,6 +190,7 @@ public class MethodAdapter implements MethodVisitor {
         mv.visitTryCatchBlock(start, end, handler, type);
     }
 
+    @Override
     public void visitLocalVariable(
         final String name,
         final String desc,
@@ -181,14 +202,17 @@ public class MethodAdapter implements MethodVisitor {
         mv.visitLocalVariable(name, desc, signature, start, end, index);
     }
 
+    @Override
     public void visitLineNumber(final int line, final Label start) {
         mv.visitLineNumber(line, start);
     }
 
+    @Override
     public void visitMaxs(final int maxStack, final int maxLocals) {
         mv.visitMaxs(maxStack, maxLocals);
     }
 
+    @Override
     public void visitEnd() {
         mv.visitEnd();
     }

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/MethodWriter.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/MethodWriter.java
@@ -461,6 +461,7 @@ class MethodWriter implements MethodVisitor {
     // Implementation of the MethodVisitor interface
     // ------------------------------------------------------------------------
 
+    @Override
     public AnnotationVisitor visitAnnotationDefault() {
         if (!ClassReader.ANNOTATIONS) {
             return null;
@@ -469,6 +470,7 @@ class MethodWriter implements MethodVisitor {
         return new AnnotationWriter(cw, false, annd, null, 0);
     }
 
+    @Override
     public AnnotationVisitor visitAnnotation(
         final String desc,
         final boolean visible)
@@ -490,6 +492,7 @@ class MethodWriter implements MethodVisitor {
         return aw;
     }
 
+    @Override
     public AnnotationVisitor visitParameterAnnotation(
         final int parameter,
         final String desc,
@@ -524,6 +527,7 @@ class MethodWriter implements MethodVisitor {
         return aw;
     }
 
+    @Override
     public void visitAttribute(final Attribute attr) {
         if (attr.isCodeAttribute()) {
             attr.next = cattrs;
@@ -534,9 +538,11 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitCode() {
     }
 
+    @Override
     public void visitFrame(
         final int type,
         final int nLocal,
@@ -638,6 +644,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitInsn(final int opcode) {
         // adds the instruction to the bytecode of the method
         code.putByte(opcode);
@@ -663,6 +670,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitIntInsn(final int opcode, final int operand) {
         // Label currentBlock = this.currentBlock;
         if (currentBlock != null) {
@@ -686,6 +694,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitVarInsn(final int opcode, final int var) {
         // Label currentBlock = this.currentBlock;
         if (currentBlock != null) {
@@ -744,6 +753,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitTypeInsn(final int opcode, final String type) {
         Item i = cw.newClassItem(type);
         // Label currentBlock = this.currentBlock;
@@ -764,6 +774,7 @@ class MethodWriter implements MethodVisitor {
         code.put12(opcode, i.index);
     }
 
+    @Override
     public void visitFieldInsn(
         final int opcode,
         final String owner,
@@ -805,6 +816,7 @@ class MethodWriter implements MethodVisitor {
         code.put12(opcode, i.index);
     }
 
+    @Override
     public void visitMethodInsn(
         final int opcode,
         final String owner,
@@ -865,6 +877,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitJumpInsn(final int opcode, final Label label) {
         Label nextInsn = null;
         // Label currentBlock = this.currentBlock;
@@ -1010,6 +1023,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitLdcInsn(final Object cst) {
         Item i = cw.newConstItem(cst);
         // Label currentBlock = this.currentBlock;
@@ -1043,6 +1057,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitIincInsn(final int var, final int increment) {
         if (currentBlock != null) {
             if (compute == FRAMES) {
@@ -1066,6 +1081,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitTableSwitchInsn(
         final int min,
         final int max,
@@ -1085,6 +1101,7 @@ class MethodWriter implements MethodVisitor {
         visitSwitchInsn(dflt, labels);
     }
 
+    @Override
     public void visitLookupSwitchInsn(
         final Label dflt,
         final int[] keys,
@@ -1130,6 +1147,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitMultiANewArrayInsn(final String desc, final int dims) {
         Item i = cw.newClassItem(desc);
         // Label currentBlock = this.currentBlock;
@@ -1146,6 +1164,7 @@ class MethodWriter implements MethodVisitor {
         code.put12(Opcodes.MULTIANEWARRAY, i.index).putByte(dims);
     }
 
+    @Override
     public void visitTryCatchBlock(
         final Label start,
         final Label end,
@@ -1167,6 +1186,7 @@ class MethodWriter implements MethodVisitor {
         lastHandler = h;
     }
 
+    @Override
     public void visitLocalVariable(
         final String name,
         final String desc,
@@ -1205,6 +1225,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitLineNumber(final int line, final Label start) {
         if (lineNumber == null) {
             lineNumber = new ByteVector();
@@ -1214,6 +1235,7 @@ class MethodWriter implements MethodVisitor {
         lineNumber.putShort(line);
     }
 
+    @Override
     public void visitMaxs(final int maxStack, final int maxLocals) {
         if (ClassReader.FRAMES && compute == FRAMES) {
             // completes the control flow graph with exception handler blocks
@@ -1444,6 +1466,7 @@ class MethodWriter implements MethodVisitor {
         }
     }
 
+    @Override
     public void visitEnd() {
     }
 

--- a/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/Type.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/objectweb/asm/Type.java
@@ -722,6 +722,7 @@ public class Type {
      * @param o the object to be compared to this type.
      * @return <tt>true</tt> if the given object is equal to this type.
      */
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -751,6 +752,7 @@ public class Type {
      * 
      * @return a hash code value for this type.
      */
+    @Override
     public int hashCode() {
         int hc = 13 * sort;
         if (sort == OBJECT || sort == ARRAY) {
@@ -766,6 +768,7 @@ public class Type {
      * 
      * @return the descriptor of this type.
      */
+    @Override
     public String toString() {
         return getDescriptor();
     }

--- a/modules/module-impl/agent/src/main/java/sun/tools/attach/BsdVirtualMachine.java
+++ b/modules/module-impl/agent/src/main/java/sun/tools/attach/BsdVirtualMachine.java
@@ -114,6 +114,7 @@ public class BsdVirtualMachine extends HotSpotVirtualMachine {
     /**
      * Detach from the target VM
      */
+    @Override
     public void detach() throws IOException {
         synchronized (this) {
             if (this.path != null) {
@@ -131,6 +132,7 @@ public class BsdVirtualMachine extends HotSpotVirtualMachine {
     /**
      * Execute the given command in the target VM.
      */
+    @Override
     InputStream execute(String cmd, Object ... args) throws AgentLoadException, IOException {
         assert args.length <= 3;                // includes null
 
@@ -223,6 +225,7 @@ public class BsdVirtualMachine extends HotSpotVirtualMachine {
             this.s = s;
         }
 
+        @Override
         public synchronized int read() throws IOException {
             byte b[] = new byte[1];
             int n = this.read(b, 0, 1);
@@ -233,6 +236,7 @@ public class BsdVirtualMachine extends HotSpotVirtualMachine {
             }
         }
 
+        @Override
         public synchronized int read(byte[] bs, int off, int len) throws IOException {
             if ((off < 0) || (off > bs.length) || (len < 0) ||
                 ((off + len) > bs.length) || ((off + len) < 0)) {
@@ -243,6 +247,7 @@ public class BsdVirtualMachine extends HotSpotVirtualMachine {
             return BsdVirtualMachine.read(s, bs, off, len);
         }
 
+        @Override
         public void close() throws IOException {
             BsdVirtualMachine.close(s);
         }

--- a/modules/module-impl/agent/src/main/java/sun/tools/attach/HotSpotVirtualMachine.java
+++ b/modules/module-impl/agent/src/main/java/sun/tools/attach/HotSpotVirtualMachine.java
@@ -73,6 +73,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
     /*
      * Load agent library - library name will be expanded in target VM
      */
+    @Override
     public void loadAgentLibrary(String agentLibrary, String options)
         throws AgentLoadException, AgentInitializationException, IOException
     {
@@ -82,6 +83,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
     /*
      * Load agent - absolute path of library provided to target VM
      */
+    @Override
     public void loadAgentPath(String agentLibrary, String options)
         throws AgentLoadException, AgentInitializationException, IOException
     {
@@ -92,6 +94,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
      * Load JPLIS agent which will load the agent JAR file and invoke
      * the agentmain method.
      */
+    @Override
     public void loadAgent(String agent, String options)
         throws AgentLoadException, AgentInitializationException, IOException
     {
@@ -137,6 +140,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
     /*
      * Send "properties" command to target VM
      */
+    @Override
     public Properties getSystemProperties() throws IOException {
         InputStream in = null;
         Properties props = new Properties();
@@ -149,6 +153,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
         return props;
     }
 
+    @Override
     public Properties getAgentProperties() throws IOException {
         InputStream in = null;
         Properties props = new Properties();

--- a/modules/module-impl/agent/src/main/java/sun/tools/attach/LinuxVirtualMachine.java
+++ b/modules/module-impl/agent/src/main/java/sun/tools/attach/LinuxVirtualMachine.java
@@ -130,6 +130,7 @@ public class LinuxVirtualMachine extends HotSpotVirtualMachine {
     /**
      * Detach from the target VM
      */
+    @Override
     public void detach() throws IOException {
         synchronized (this) {
             if (this.path != null) {
@@ -147,6 +148,7 @@ public class LinuxVirtualMachine extends HotSpotVirtualMachine {
     /**
      * Execute the given command in the target VM.
      */
+    @Override
     InputStream execute(String cmd, Object ... args) throws AgentLoadException, IOException {
         assert args.length <= 3;                // includes null
 
@@ -239,6 +241,7 @@ public class LinuxVirtualMachine extends HotSpotVirtualMachine {
             this.s = s;
         }
 
+        @Override
         public synchronized int read() throws IOException {
             byte b[] = new byte[1];
             int n = this.read(b, 0, 1);
@@ -249,6 +252,7 @@ public class LinuxVirtualMachine extends HotSpotVirtualMachine {
             }
         }
 
+        @Override
         public synchronized int read(byte[] bs, int off, int len) throws IOException {
             if ((off < 0) || (off > bs.length) || (len < 0) ||
                 ((off + len) > bs.length) || ((off + len) < 0)) {
@@ -259,6 +263,7 @@ public class LinuxVirtualMachine extends HotSpotVirtualMachine {
             return LinuxVirtualMachine.read(s, bs, off, len);
         }
 
+        @Override
         public void close() throws IOException {
             LinuxVirtualMachine.close(s);
         }

--- a/modules/module-impl/agent/src/main/java/sun/tools/attach/SolarisVirtualMachine.java
+++ b/modules/module-impl/agent/src/main/java/sun/tools/attach/SolarisVirtualMachine.java
@@ -103,6 +103,7 @@ public class SolarisVirtualMachine extends HotSpotVirtualMachine {
     /**
      * Detach from the target VM
      */
+    @Override
     public void detach() throws IOException {
         synchronized (this) {
             if (fd != -1) {
@@ -115,6 +116,7 @@ public class SolarisVirtualMachine extends HotSpotVirtualMachine {
     /**
      * Execute the given command in the target VM.
      */
+    @Override
     InputStream execute(String cmd, Object ... args) throws AgentLoadException, IOException {
         assert args.length <= 3;                // includes null
 
@@ -167,6 +169,7 @@ public class SolarisVirtualMachine extends HotSpotVirtualMachine {
             this.s = s;
         }
 
+        @Override
         public synchronized int read() throws IOException {
             byte b[] = new byte[1];
             int n = this.read(b, 0, 1);
@@ -177,6 +180,7 @@ public class SolarisVirtualMachine extends HotSpotVirtualMachine {
             }
         }
 
+        @Override
         public synchronized int read(byte[] bs, int off, int len) throws IOException {
             if ((off < 0) || (off > bs.length) || (len < 0) ||
                 ((off + len) > bs.length) || ((off + len) < 0)) {
@@ -187,6 +191,7 @@ public class SolarisVirtualMachine extends HotSpotVirtualMachine {
             return SolarisVirtualMachine.read(s, bs, off, len);
         }
 
+        @Override
         public void close() throws IOException {
             SolarisVirtualMachine.close(s);
         }

--- a/modules/module-impl/agent/src/main/java/sun/tools/attach/WindowsVirtualMachine.java
+++ b/modules/module-impl/agent/src/main/java/sun/tools/attach/WindowsVirtualMachine.java
@@ -65,6 +65,7 @@ public class WindowsVirtualMachine extends HotSpotVirtualMachine {
         }
     }
 
+    @Override
     public void detach() throws IOException {
         synchronized (this) {
             if (hProcess != -1) {
@@ -74,6 +75,7 @@ public class WindowsVirtualMachine extends HotSpotVirtualMachine {
         }
     }
 
+    @Override
     InputStream execute(String cmd, Object ... args)
         throws AgentLoadException, IOException
     {
@@ -131,6 +133,7 @@ public class WindowsVirtualMachine extends HotSpotVirtualMachine {
             this.hPipe = hPipe;
         }
 
+        @Override
         public synchronized int read() throws IOException {
             byte b[] = new byte[1];
             int n = this.read(b, 0, 1);
@@ -141,6 +144,7 @@ public class WindowsVirtualMachine extends HotSpotVirtualMachine {
             }
         }
 
+        @Override
         public synchronized int read(byte[] bs, int off, int len) throws IOException {
             if ((off < 0) || (off > bs.length) || (len < 0) ||
                 ((off + len) > bs.length) || ((off + len) < 0)) {
@@ -151,6 +155,7 @@ public class WindowsVirtualMachine extends HotSpotVirtualMachine {
             return WindowsVirtualMachine.readPipe(hPipe, bs, off, len);
         }
 
+        @Override
         public void close() throws IOException {
             if (hPipe != -1) {
                 WindowsVirtualMachine.closePipe(hPipe);

--- a/modules/module-impl/junit3/src/main/java/org/powermock/modules/junit3/internal/impl/PowerMockJUnit3RunnerDelegateImpl.java
+++ b/modules/module-impl/junit3/src/main/java/org/powermock/modules/junit3/internal/impl/PowerMockJUnit3RunnerDelegateImpl.java
@@ -99,6 +99,7 @@ public class PowerMockJUnit3RunnerDelegateImpl extends TestSuite implements Powe
         }
     }
 
+    @Override
     public Class<?> getTestClass() {
         return testClass;
     }
@@ -121,6 +122,7 @@ public class PowerMockJUnit3RunnerDelegateImpl extends TestSuite implements Powe
      */
     private static Test warning(final String message) {
         return new TestCase("warning") {
+            @Override
             protected void runTest() {
                 fail(message);
             }

--- a/modules/module-impl/junit3/src/main/java/org/powermock/modules/junit3/internal/impl/PowerMockJUnit3TestListener.java
+++ b/modules/module-impl/junit3/src/main/java/org/powermock/modules/junit3/internal/impl/PowerMockJUnit3TestListener.java
@@ -39,15 +39,18 @@ public class PowerMockJUnit3TestListener implements TestListener {
 	/**
 	 * Does nothing.
 	 */
+	@Override
 	public void addError(Test test, Throwable t) {
 	}
 
 	/**
 	 * Does nothing.
 	 */
+	@Override
 	public void addFailure(Test test, AssertionFailedError t) {
 	}
 
+	@Override
 	public void endTest(Test test) {
 		try {
 			Class<?> powerMockClass = mockClassLoader.loadClass(MockRepository.class.getName());
@@ -65,6 +68,7 @@ public class PowerMockJUnit3TestListener implements TestListener {
 	/**
 	 * Does nothing.
 	 */
+	@Override
 	public void startTest(Test test) {
 	}
 }

--- a/modules/module-impl/junit4-common/src/main/java/org/powermock/modules/junit4/common/internal/impl/AbstractCommonPowerMockRunner.java
+++ b/modules/module-impl/junit4-common/src/main/java/org/powermock/modules/junit4/common/internal/impl/AbstractCommonPowerMockRunner.java
@@ -62,10 +62,12 @@ public abstract class AbstractCommonPowerMockRunner extends Runner implements Fi
         return suiteChunker.getTestCount();
     }
 
+    @Override
     public void filter(Filter filter) throws NoTestsRemainException {
         suiteChunker.filter(filter);
     }
 
+    @Override
     public void sort(Sorter sorter) {
         suiteChunker.sort(sorter);
     }

--- a/modules/module-impl/junit4-common/src/main/java/org/powermock/modules/junit4/common/internal/impl/JUnit4TestSuiteChunkerImpl.java
+++ b/modules/module-impl/junit4-common/src/main/java/org/powermock/modules/junit4/common/internal/impl/JUnit4TestSuiteChunkerImpl.java
@@ -71,6 +71,7 @@ public class JUnit4TestSuiteChunkerImpl extends AbstractTestSuiteChunkerImpl<Pow
 		}
 	}
 
+	@Override
 	public void run(RunNotifier notifier) {
 		List<TestChunk> chunkEntries = getTestChunks();
 		Iterator<TestChunk> iterator = chunkEntries.iterator();
@@ -121,6 +122,7 @@ public class JUnit4TestSuiteChunkerImpl extends AbstractTestSuiteChunkerImpl<Pow
 		powerMockTestNotifier.notifyAfterTestSuiteEnded(testClass, allMethodsAsArray, testSuiteResult);
 	}
 
+	@Override
 	public boolean shouldExecuteTestForMethod(Class<?> testClass, Method potentialTestMethod) {
 		return (potentialTestMethod.getName().startsWith("test")
 				&& Modifier.isPublic(potentialTestMethod.getModifiers())
@@ -159,6 +161,7 @@ public class JUnit4TestSuiteChunkerImpl extends AbstractTestSuiteChunkerImpl<Pow
 		return newInstance;
 	}
 
+	@Override
 	public synchronized int getTestCount() {
 		if (testCount == NOT_INITIALIZED) {
 			testCount = 0;
@@ -169,6 +172,7 @@ public class JUnit4TestSuiteChunkerImpl extends AbstractTestSuiteChunkerImpl<Pow
 		return testCount;
 	}
 
+	@Override
 	public Description getDescription() {
 		if (description == null) {
 			if (delegates.size() == 0) {
@@ -200,6 +204,7 @@ public class JUnit4TestSuiteChunkerImpl extends AbstractTestSuiteChunkerImpl<Pow
 		return description;
 	}
 
+	@Override
 	public void filter(Filter filter) throws NoTestsRemainException {
 		for (Object delegate : delegates) {
 			if (delegate instanceof Filterable) {
@@ -208,6 +213,7 @@ public class JUnit4TestSuiteChunkerImpl extends AbstractTestSuiteChunkerImpl<Pow
 		}
 	}
 
+	@Override
 	public void sort(Sorter sorter) {
 		for (Object delegate : delegates) {
 			if (delegate instanceof Sortable) {

--- a/modules/module-impl/junit4-common/src/main/java/org/powermock/modules/junit4/common/internal/impl/VersionComparator.java
+++ b/modules/module-impl/junit4-common/src/main/java/org/powermock/modules/junit4/common/internal/impl/VersionComparator.java
@@ -26,6 +26,7 @@ class VersionComparator implements Comparator {
         return compare(o1, o2) == 0;
     }
 
+    @Override
     public int compare(Object o1, Object o2) {
         String version1 = (String) o1;
         String version2 = (String) o2;

--- a/modules/module-impl/junit4-rule-agent/src/main/java/org/powermock/modules/junit4/rule/PowerMockRule.java
+++ b/modules/module-impl/junit4-rule-agent/src/main/java/org/powermock/modules/junit4/rule/PowerMockRule.java
@@ -37,6 +37,7 @@ public class PowerMockRule implements MethodRule {
         PowerMockAgent.initializeIfPossible();
     }
 
+    @Override
     public Statement apply(Statement base, FrameworkMethod method, Object target) {
         PowerMockAgentTestInitializer.initialize(target.getClass());
 

--- a/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/DelegatingPowerMockRunner.java
+++ b/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/DelegatingPowerMockRunner.java
@@ -94,6 +94,7 @@ implements PowerMockJUnitRunnerDelegate, Filterable {
          */
         return withContextClassLoader(testClass.getClassLoader(),
                 new Callable<Runner>() {
+            @Override
             public Runner call() throws Exception {
                 try {
                     return Whitebox.invokeConstructor(
@@ -137,6 +138,7 @@ implements PowerMockJUnitRunnerDelegate, Filterable {
     public void run(final RunNotifier notifier) {
         try {
             withContextClassLoader(testClassLoader, new Callable<Void>() {
+                @Override
                 public Void call() {
                     PowerMockRunNotifier powerNotifier = new PowerMockRunNotifier(
                             notifier, powerMockTestNotifier, testMethods);

--- a/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/NotificationBuilder.java
+++ b/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/NotificationBuilder.java
@@ -121,6 +121,7 @@ class NotificationBuilder {
                     testInstance, testMethod, unsupportedMethodArgs, this);
         }
 
+        @Override
         public Result getResult() {
             return this.result;
         }

--- a/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockJUnit44RunnerDelegateImpl.java
+++ b/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockJUnit44RunnerDelegateImpl.java
@@ -116,6 +116,7 @@ public class PowerMockJUnit44RunnerDelegateImpl extends Runner implements Filter
     @Override
     public void run(final RunNotifier notifier) {
         new ClassRoadie(notifier, testClass, getDescription(), new Runnable() {
+            @Override
             public void run() {
                 runMethods(notifier);
             }
@@ -234,6 +235,7 @@ public class PowerMockJUnit44RunnerDelegateImpl extends Runner implements Filter
         return method.getAnnotations();
     }
 
+    @Override
     public void filter(Filter filter) throws NoTestsRemainException {
         for (Iterator<Method> iter = testMethods.iterator(); iter.hasNext(); ) {
             Method method = iter.next();
@@ -244,8 +246,10 @@ public class PowerMockJUnit44RunnerDelegateImpl extends Runner implements Filter
             throw new NoTestsRemainException();
     }
 
+    @Override
     public void sort(final Sorter sorter) {
         Collections.sort(testMethods, new Comparator<Method>() {
+            @Override
             public int compare(Method o1, Method o2) {
                 return sorter.compare(methodDescription(o1), methodDescription(o2));
             }
@@ -256,10 +260,12 @@ public class PowerMockJUnit44RunnerDelegateImpl extends Runner implements Filter
         return testClass;
     }
 
+    @Override
     public int getTestCount() {
         return testMethods.size();
     }
 
+    @Override
     public Class<?> getTestClass() {
         return testClass.getJavaClass();
     }

--- a/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockRunNotifier.java
+++ b/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockRunNotifier.java
@@ -70,11 +70,13 @@ implements GlobalNotificationBuildSupport.Callback {
         return this.suiteClass;
     }
 
+    @Override
     public void suiteClassInitiated(Class<?> testClass) {
         this.suiteClass = testClass;
         notificationBuilder.get().testSuiteStarted(testClass);
     }
 
+    @Override
     public void testInstanceCreated(Object testInstance) {
         if (Thread.currentThread() == motherThread) {
             pendingTestInstancesOnMotherThread.add(testInstance);

--- a/modules/module-impl/testng-agent/src/main/java/org/powermock/modules/testng/PowerMockObjectFactory.java
+++ b/modules/module-impl/testng-agent/src/main/java/org/powermock/modules/testng/PowerMockObjectFactory.java
@@ -36,6 +36,7 @@ public class PowerMockObjectFactory implements IObjectFactory {
 
     private ObjectFactoryImpl defaultObjectFactory = new ObjectFactoryImpl();
 
+    @Override
     public Object newInstance(Constructor constructor, Object... params) {
         final Class<?> testClass = constructor.getDeclaringClass();
         PowerMockAgentTestInitializer.initialize(testClass);

--- a/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/PowerMockObjectFactory.java
+++ b/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/PowerMockObjectFactory.java
@@ -35,6 +35,7 @@ public class PowerMockObjectFactory implements IObjectFactory {
 
     private ObjectFactoryImpl defaultObjectFactory = new ObjectFactoryImpl();
 
+    @Override
     public Object newInstance(Constructor constructor, Object... params) {
         final Object testInstance;
         Class<?> testClass = constructor.getDeclaringClass();

--- a/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/PowerMockClassloaderObjectFactory.java
+++ b/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/PowerMockClassloaderObjectFactory.java
@@ -63,6 +63,7 @@ public class PowerMockClassloaderObjectFactory implements IObjectFactory {
                 staticConstructorSuppressExtractor = new StaticConstructorSuppressExtractorImpl();
 	}
 
+	@Override
 	public Object newInstance(@SuppressWarnings("rawtypes") Constructor constructor, Object... params) {
 		/*
 		 * For extra safety clear the MockitoRepository on each new

--- a/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/PowerMockTestNGMethodHandler.java
+++ b/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/PowerMockTestNGMethodHandler.java
@@ -43,6 +43,7 @@ public class PowerMockTestNGMethodHandler implements MethodHandler {
         }
     }
 
+    @Override
     public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
         injectMocksUsingAnnotationEnabler(self);
         try {

--- a/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/TestNGMethodFilter.java
+++ b/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/TestNGMethodFilter.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
  * replayAll/verifyAll doesn't work as expected.
  */
 public class TestNGMethodFilter implements MethodFilter {
+    @Override
     public boolean isHandled(Method method) {
         return !isToString(method) && !isHashCode(method) && !isFinalize(method) && !isEquals(method);
     }

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/MockPolicyUsageExampleTest.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/MockPolicyUsageExampleTest.java
@@ -45,10 +45,12 @@ public class MockPolicyUsageExampleTest {
 }
 
 class MockPolicyExample implements PowerMockPolicy {
+	@Override
 	public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
 		settings.addFullyQualifiedNamesOfClassesToLoadByMockClassloader(ResultCalculator.class.getName());
 	}
 
+	@Override
 	public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
 		Method calculateMethod = Whitebox.getMethod(ResultCalculator.class);
 		settings.stubMethod(calculateMethod, 4);

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/MockPolicyWithExpectationsTest.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/MockPolicyWithExpectationsTest.java
@@ -49,10 +49,12 @@ public class MockPolicyWithExpectationsTest {
 }
 
 class MockPolicyExpectationsExample implements PowerMockPolicy {
+	@Override
 	public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
 		settings.addFullyQualifiedNamesOfClassesToLoadByMockClassloader(ResultCalculator.class.getName());
 	}
 
+	@Override
 	public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
 		final ResultCalculator calculatorMock = createMock(ResultCalculator.class);
 		expect(calculatorMock.calculate()).andReturn(2.0);

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/MockPolicyWithInvocationHandlerTest.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/MockPolicyWithInvocationHandlerTest.java
@@ -50,13 +50,16 @@ public class MockPolicyWithInvocationHandlerTest {
 }
 
 class MockPolicyInvocationHandlerExample implements PowerMockPolicy {
+	@Override
 	public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
 		settings.addFullyQualifiedNamesOfClassesToLoadByMockClassloader(ResultCalculator.class.getName());
 	}
 
+	@Override
 	public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
 		settings.proxyMethod(method(ResultCalculator.class), new InvocationHandler() {
 
+			@Override
 			public Object invoke(Object object, Method method, Object[] args) throws Throwable {
 				final double result = (Double) method.invoke(object, args);
 				return result + 1.0;

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/frameworkexample/SimpleFrameworkMockPolicy.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/mockpolicy/frameworkexample/SimpleFrameworkMockPolicy.java
@@ -28,10 +28,12 @@ public class SimpleFrameworkMockPolicy implements PowerMockPolicy {
 
 	public static final String NATIVE_RESULT_VALUE = "result";
 
+	@Override
 	public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
 		settings.addStaticInitializersToSuppress("samples.mockpolicy.frameworkexample.SimpleFramework");
 	}
 
+	@Override
 	public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
 		final Method doNativeStuffMethod = Whitebox.getMethod(SimpleFramework.class, String.class);
 		NativeResult nativeResult = new NativeResult(NATIVE_RESULT_VALUE);

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/prepareeverything/ExpectNewDemoUsingThePrepareEverythingAnnotationTest.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/prepareeverything/ExpectNewDemoUsingThePrepareEverythingAnnotationTest.java
@@ -478,6 +478,7 @@ public class ExpectNewDemoUsingThePrepareEverythingAnnotationTest {
 
         final Service serviceSubTypeInstance = new Service() {
 
+            @Override
             public String getServiceMessage() {
                 return "message";
             }

--- a/modules/module-test/easymock/junit410-test/src/test/java/samples/junit410/expectnew/ExpectNewDemoTest.java
+++ b/modules/module-test/easymock/junit410-test/src/test/java/samples/junit410/expectnew/ExpectNewDemoTest.java
@@ -479,6 +479,7 @@ public class ExpectNewDemoTest {
 
         final Service serviceSubTypeInstance = new Service() {
 
+            @Override
             public String getServiceMessage() {
                 return "message";
             }

--- a/modules/module-test/easymock/junit410-test/src/test/java/samples/junit410/rules/impl/SimpleEasyMockJUnitRule.java
+++ b/modules/module-test/easymock/junit410-test/src/test/java/samples/junit410/rules/impl/SimpleEasyMockJUnitRule.java
@@ -51,6 +51,7 @@ public class SimpleEasyMockJUnitRule implements MethodRule {
         control.verify();
     }
 
+    @Override
     public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
         return new Statement() {
 

--- a/modules/module-test/easymock/junit47-test/src/test/java/samples/junit4/rules/AssertThatJUnit47RulesWorks.java
+++ b/modules/module-test/easymock/junit47-test/src/test/java/samples/junit4/rules/AssertThatJUnit47RulesWorks.java
@@ -53,6 +53,7 @@ public class AssertThatJUnit47RulesWorks {
 	}
 
 	private class MyRule implements MethodRule {
+		@Override
 		public Statement apply(final Statement base, FrameworkMethod method, Object target) {
 			return new Statement() {
 				@Override

--- a/modules/module-test/easymock/junit48-test/src/test/java/samples/junit48/rules/AssertThatJUnit48RulesWorks.java
+++ b/modules/module-test/easymock/junit48-test/src/test/java/samples/junit48/rules/AssertThatJUnit48RulesWorks.java
@@ -53,6 +53,7 @@ public class AssertThatJUnit48RulesWorks {
 	}
 
 	private class MyRule implements MethodRule {
+		@Override
 		public Statement apply(final Statement base, FrameworkMethod method, Object target) {
 			return new Statement() {
 				@Override

--- a/modules/module-test/easymock/junit48-test/src/test/java/samples/junit48/rules/impl/SimpleEasyMockJUnitRule.java
+++ b/modules/module-test/easymock/junit48-test/src/test/java/samples/junit48/rules/impl/SimpleEasyMockJUnitRule.java
@@ -51,6 +51,7 @@ public class SimpleEasyMockJUnitRule implements MethodRule {
         control.verify();
     }
 
+    @Override
     public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
         return new Statement() {
 

--- a/modules/module-test/mockito/junit4-agent/src/test/java/powermock/modules/test/mockito/junit4/agent/AssertPowerMockRuleDelagatesToOtherRulesTest.java
+++ b/modules/module-test/mockito/junit4-agent/src/test/java/powermock/modules/test/mockito/junit4/agent/AssertPowerMockRuleDelagatesToOtherRulesTest.java
@@ -57,6 +57,7 @@ public class AssertPowerMockRuleDelagatesToOtherRulesTest {
 	}
 
 	private class MyRule implements MethodRule {
+		@Override
 		public Statement apply(final Statement base, FrameworkMethod method, Object target) {
 			return new Statement() {
 				@Override

--- a/modules/module-test/mockito/junit4-agent/src/test/java/powermock/modules/test/mockito/junit4/agent/MemberModificationExampleTest.java
+++ b/modules/module-test/mockito/junit4-agent/src/test/java/powermock/modules/test/mockito/junit4/agent/MemberModificationExampleTest.java
@@ -176,6 +176,7 @@ public class MemberModificationExampleTest {
     }
 
     private final class ReturnValueChangingInvocationHandler implements InvocationHandler {
+        @Override
         public Object invoke(Object object, Method method, Object[] arguments) throws Throwable {
             if (arguments[0].equals("make it a string")) {
                 return "hello world";

--- a/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/SuppressedMethodStubbing.java
+++ b/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/SuppressedMethodStubbing.java
@@ -34,6 +34,7 @@ public enum SuppressedMethodStubbing {
                 @Override
                 public void verify(final Callable<?> invocation) throws Exception {
                     super.verify(new Callable<Exception>() {
+                        @Override
                         public Exception call() {
                             try {
                                 invocation.call();
@@ -66,6 +67,7 @@ public enum SuppressedMethodStubbing {
         assertEquals(value, invocation.call());
     }
 
+    @Override
     public String toString() {
         return "returns " + value;
     }

--- a/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/parameterized/StubMethodTest.java
+++ b/modules/module-test/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/parameterized/StubMethodTest.java
@@ -50,6 +50,7 @@ public class StubMethodTest {
 
         final SuppressMethod tested = new SuppressMethod();
         Callable<?> methodInvocation = new Callable<Object>() {
+            @Override
             public Object call() {
                 return method.invokeOn(tested);
             }

--- a/modules/module-test/mockito/junit4-rule-objenesis/src/test/java/org/powermock/modules/test/junit4/rule/objenesis/PrivateInstanceMockingTest.java
+++ b/modules/module-test/mockito/junit4-rule-objenesis/src/test/java/org/powermock/modules/test/junit4/rule/objenesis/PrivateInstanceMockingTest.java
@@ -89,6 +89,7 @@ public class PrivateInstanceMockingTest {
         when(tested, "doObjectInternal", isA(String.class)).thenAnswer(new Answer<Void>() {
             private static final long serialVersionUID = 20645008237481667L;
 
+            @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 assertEquals("Testing", invocation.getArguments()[0]);
                 return null;

--- a/modules/module-test/mockito/junit4-rule-xstream/src/test/java/org/powermock/modules/test/junit4/rule/xstream/WhenNewTest.java
+++ b/modules/module-test/mockito/junit4-rule-xstream/src/test/java/org/powermock/modules/test/junit4/rule/xstream/WhenNewTest.java
@@ -417,6 +417,7 @@ public class WhenNewTest {
 
 		final Service serviceSubTypeInstance = new Service() {
 
+			@Override
 			public String getServiceMessage() {
 				return "message";
 			}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/membermodification/MemberModificationExampleTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/membermodification/MemberModificationExampleTest.java
@@ -175,6 +175,7 @@ public class MemberModificationExampleTest {
     }
 
     private final class ReturnValueChangingInvocationHandler implements InvocationHandler {
+        @Override
         public Object invoke(Object object, Method method, Object[] arguments) throws Throwable {
             if (arguments[0].equals("make it a string")) {
                 return "hello world";

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/partialmocking/StaticPartialMockingTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/partialmocking/StaticPartialMockingTest.java
@@ -70,6 +70,7 @@ public class StaticPartialMockingTest {
 
         assertTrue(Object.class.equals(StaticExample.objectMethod().getClass()));
         doAnswer(new Answer<String>() {
+            @Override
             public String answer(InvocationOnMock invocation) throws Throwable {
                 return "Hello static";
             }
@@ -190,6 +191,7 @@ public class StaticPartialMockingTest {
         spy(StaticExample.class);
 
         doAnswer(new Answer<String>() {
+            @Override
             public String answer(InvocationOnMock invocation) throws Throwable {
                 return "something";
             }

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/privatemocking/PrivateInstanceMockingTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/privatemocking/PrivateInstanceMockingTest.java
@@ -126,6 +126,7 @@ public class PrivateInstanceMockingTest {
         when(tested, "doObjectInternal", isA(String.class)).thenAnswer(new Answer<Void>() {
             private static final long serialVersionUID = 20645008237481667L;
 
+            @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 assertEquals("Testing", invocation.getArguments()[0]);
                 return null;

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/proxymethod/ProxyMethodTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/proxymethod/ProxyMethodTest.java
@@ -106,18 +106,21 @@ public class ProxyMethodTest {
 	}
 
 	private final class ThrowingInvocationHandler implements InvocationHandler {
+		@Override
 		public Object invoke(Object object, Method method, Object[] arguments) throws Throwable {
 			throw new ArrayStoreException();
 		}
 	}
 
 	private final class ReturnValueChangingInvocationHandler implements InvocationHandler {
+		@Override
 		public Object invoke(Object object, Method method, Object[] arguments) throws Throwable {
 			return "hello world";
 		}
 	}
 
 	private final class DelegatingInvocationHandler implements InvocationHandler {
+		@Override
 		public Object invoke(Object object, Method method, Object[] arguments) throws Throwable {
 			return method.invoke(object, arguments);
 		}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/whennew/WhenNewTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/whennew/WhenNewTest.java
@@ -414,6 +414,7 @@ public class WhenNewTest {
 
         final Service serviceSubTypeInstance = new Service() {
 
+            @Override
             public String getServiceMessage() {
                 return "message";
             }

--- a/modules/module-test/mockito/junit49/src/test/java/samples/powermockito/junit4/rules/JUnit49RuleTest.java
+++ b/modules/module-test/mockito/junit49/src/test/java/samples/powermockito/junit4/rules/JUnit49RuleTest.java
@@ -64,6 +64,7 @@ public class JUnit49RuleTest {
 
     private class MyRule implements TestRule {
 
+        @Override
         public Statement apply(final Statement statement, Description description) {
             return new Statement() {
                 @Override

--- a/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -208,6 +208,7 @@ public class WhiteboxImpl {
         if (Modifier.isInterface(modifiers)) {
             object = Proxy.newProxyInstance(WhiteboxImpl.class.getClassLoader(), new Class<?>[]{classToInstantiate},
                     new InvocationHandler() {
+                        @Override
                         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                             return TypeUtils.getDefaultValue(method.getReturnType());
                         }
@@ -961,6 +962,7 @@ public class WhiteboxImpl {
                 * invoke.
                 */
             Arrays.sort(methods, new Comparator<Method>() {
+                @Override
                 public int compare(Method m1, Method m2) {
                     final Class<?>[] typesMethod1 = m1.getParameterTypes();
                     final Class<?>[] typesMethod2 = m2.getParameterTypes();
@@ -1491,6 +1493,7 @@ public class WhiteboxImpl {
             final Class<?> type = thisType;
             final Method[] declaredMethods = AccessController.doPrivileged(new PrivilegedAction<Method[]>() {
 
+                @Override
                 public Method[] run() {
                     return type.getDeclaredMethods();
                 }

--- a/reflect/src/main/java/org/powermock/reflect/internal/matcherstrategies/FieldNameMatcherStrategy.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/matcherstrategies/FieldNameMatcherStrategy.java
@@ -41,6 +41,7 @@ public class FieldNameMatcherStrategy extends FieldMatcherStrategy {
                 isInstanceField ? "instance" : "static", fieldName, type.getName()));
     }
 
+    @Override
     public String toString() {
         return "fieldName " + fieldName;
     }

--- a/tests/utils/src/main/java/samples/classwithinnermembers/ClassWithInnerMembers.java
+++ b/tests/utils/src/main/java/samples/classwithinnermembers/ClassWithInnerMembers.java
@@ -26,6 +26,7 @@ public class ClassWithInnerMembers {
 
 	private static class MyInnerClass implements InnerInterface {
 
+		@Override
 		public String doStuff() {
 			return "member class";
 		}
@@ -39,6 +40,7 @@ public class ClassWithInnerMembers {
 			this.value = value;
 		}
 
+		@Override
 		public String doStuff() {
 			return value;
 		}
@@ -52,6 +54,7 @@ public class ClassWithInnerMembers {
 			this.value = value;
 		}
 
+		@Override
 		public String doStuff() {
 			return value;
 		}
@@ -71,6 +74,7 @@ public class ClassWithInnerMembers {
 
 	public String getLocalClassValue() {
 		class MyLocalClass implements InnerInterface {
+			@Override
 			public String doStuff() {
 				return "local class";
 			}
@@ -88,6 +92,7 @@ public class ClassWithInnerMembers {
 				this.value = value;
 			}
 
+			@Override
 			public String doStuff() {
 				return value;
 			}
@@ -99,6 +104,7 @@ public class ClassWithInnerMembers {
 	public String getValueForAnonymousInnerClass() {
 
 		InnerInterface inner = new InnerInterface() {
+			@Override
 			public String doStuff() {
 				return "value";
 			}

--- a/tests/utils/src/main/java/samples/hashcode/HashCodeInitializedInCtor.java
+++ b/tests/utils/src/main/java/samples/hashcode/HashCodeInitializedInCtor.java
@@ -29,6 +29,7 @@ public class HashCodeInitializedInCtor {
         return fault;
     }
 
+    @Override
     public final int hashCode() {
         return hash.hashCode();
     }

--- a/tests/utils/src/main/java/samples/rule/SimpleThingImpl.java
+++ b/tests/utils/src/main/java/samples/rule/SimpleThingImpl.java
@@ -18,6 +18,7 @@ package samples.rule;
 
 public class SimpleThingImpl implements SimpleThing {
 
+    @Override
     public String getThingName() {
         return null;
     }

--- a/tests/utils/src/main/java/samples/singleton/StaticService.java
+++ b/tests/utils/src/main/java/samples/singleton/StaticService.java
@@ -31,6 +31,7 @@ public class StaticService {
 
 	public static int getNumberFromInner() {
 		return new Callable<Integer>() {
+			@Override
 			public Integer call() {
 				return number;
 			}
@@ -43,6 +44,7 @@ public class StaticService {
 
 	public int internalGetNumberFromInnerInstance() {
 		return new Callable<Integer>() {
+			@Override
 			public Integer call() {
 				return secret;
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1161 - "@Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1161.

Please let me know if you have any questions.

Christian