### PR TITLE
Nest statements generated by rules.

### DIFF
--- a/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockJUnit49RunnerDelegateImpl.java
+++ b/modules/module-impl/junit4/src/main/java/org/powermock/modules/junit4/internal/impl/PowerMockJUnit49RunnerDelegateImpl.java
@@ -57,7 +57,7 @@ public class PowerMockJUnit49RunnerDelegateImpl extends PowerMockJUnit47RunnerDe
 
         @Override
         protected Statement applyRuleToLastStatement(final Method method, final Object testInstance, Field field,
-                final LastRuleTestExecutorStatement lastStatement) throws IllegalAccessException {
+                final Statement lastStatement) throws IllegalAccessException {
             final Object fieldValue = field.get(testInstance);
             final Statement statement;
             if (fieldValue instanceof MethodRule) {


### PR DESCRIPTION
This is how rules are used by JUnit itself. It avoids different behaviour of tests when they are run with the PowerMockRunner instead of JUnit's default runner. Fixes #427.