### PR TITLE
Whitebox.invokeConstructor may not work as expected with overloaded constructors

### DIFF
--- a/reflect/src/main/java/org/powermock/reflect/internal/CandidateConstructorSearcher.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/CandidateConstructorSearcher.java
@@ -1,0 +1,93 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.reflect.internal;
+
+import org.powermock.reflect.internal.comparator.ComparatorFactory;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ *  This class search the best candidate in the given class to invoke constructor with given parameters.
+ */
+class CandidateConstructorSearcher<T> {
+    private final Class<T> classThatContainsTheConstructorToTest;
+    private final Class<?>[] argumentTypes;
+
+    public CandidateConstructorSearcher(Class<T> classThatContainsTheConstructorToTest, Class<?>[] argumentTypes) {
+
+        this.classThatContainsTheConstructorToTest = classThatContainsTheConstructorToTest;
+        this.argumentTypes = argumentTypes;
+    }
+    
+    public Constructor<T> findConstructor() {
+        final Constructor<T>[] constructors = getConstructors();
+        if (constructors.length == 0) {
+            return null;
+        }
+        if (constructors.length == 1) {
+            return constructors[0];
+        } else {
+            return findBestCandidate(constructors);
+
+        }
+    }
+
+    private Constructor<T> findBestCandidate(Constructor<T>[] constructors) {
+        //We've found overloaded constructor, we need to find the best one to invoke.
+        Arrays.sort(constructors, ComparatorFactory.createConstructorComparator());
+        return constructors[0];
+    }
+
+    @SuppressWarnings("unchecked")
+    private Constructor<T>[] getConstructors() {
+
+        try {
+            Constructor<?>[] declaredConstructors = classThatContainsTheConstructorToTest.getDeclaredConstructors();
+            List<Constructor<?>> constructors = new ArrayList<Constructor<?>>();
+            for (Constructor<?> constructor : declaredConstructors) {
+                if (argumentsApplied(constructor)) {
+                    constructors.add(constructor);
+                }
+            }
+            return constructors.toArray(new Constructor[constructors.size()]);
+        } catch (Exception e) {
+            return new Constructor[0];
+        }
+
+    }
+
+    private boolean argumentsApplied(Constructor<?> constructor) {
+        Class<?>[] constructorArgumentTypes = constructor.getParameterTypes();
+        if (constructorArgumentTypes.length != argumentTypes.length) {
+            return false;
+        }
+
+        for (int index = 0; index < argumentTypes.length; index++) {
+            if (!constructorArgumentTypes[index].isAssignableFrom(argumentTypes[index])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+
+}

--- a/reflect/src/main/java/org/powermock/reflect/internal/comparator/ComparatorFactory.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/comparator/ComparatorFactory.java
@@ -1,0 +1,107 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.reflect.internal.comparator;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Comparator;
+
+/**
+ *  This comparator factory is used to create Comparators for
+ *  {@link org.powermock.reflect.Whitebox} which are used to find best candidates
+ *  for constructor and method invocation.
+ *  @see org.powermock.reflect.internal.WhiteboxImpl#getBestMethodCandidate(Class, String, Class[], boolean)
+ *  @see org.powermock.reflect.internal.WhiteboxImpl#getBestCandidateConstructor(Class, Class[], Object[])
+ *  @see org.powermock.reflect.internal.CandidateConstructorSearcher
+ */
+public class ComparatorFactory {
+
+    private ComparatorFactory() {
+    }
+
+    public static Comparator<Constructor> createConstructorComparator(){
+        return new ConstructorComparator(new ParametersComparator());
+    }
+
+    public static Comparator<Method> createMethodComparator(){
+        return new MethodComparator(new ParametersComparator());
+    }
+
+
+    public static class ConstructorComparator implements Comparator<Constructor> {
+        private final ParametersComparator parametersComparator;
+
+        private ConstructorComparator(ParametersComparator parametersComparator) {
+
+            this.parametersComparator = parametersComparator;
+        }
+
+        @Override
+        public int compare(Constructor constructor1, Constructor constructor2) {
+            final Class<?>[] parameters1 = constructor1.getParameterTypes();
+            final Class<?>[] parameters2 = constructor2.getParameterTypes();
+            return parametersComparator.compare(parameters1,parameters2);
+        }
+    }
+
+    /**
+     *
+     */
+    public static class MethodComparator implements Comparator<Method> {
+        private final ParametersComparator parametersComparator;
+
+        private MethodComparator(ParametersComparator parametersComparator) {
+
+            this.parametersComparator = parametersComparator;
+        }
+
+        @Override
+        public int compare(Method m1, Method m2) {
+            final Class<?>[] typesMethod1 = m1.getParameterTypes();
+            final Class<?>[] typesMethod2 = m2.getParameterTypes();
+            return parametersComparator.compare(typesMethod1, typesMethod2);
+
+        }
+    }
+
+    private static class ParametersComparator implements Comparator<Class[]>{
+
+        @Override
+        public int compare(Class[] params1, Class[] params2) {
+            final int size = params1.length;
+            for (int i = 0; i < size; i++) {
+                Class<?> type1 = params1[i];
+                Class<?> type2 = params2[i];
+                if (!type1.equals(type2)) {
+                    if (type1.isAssignableFrom(type2)) {
+                        if (!type1.isArray() && type2.isArray()) {
+                            return -1;
+                        }
+                        return 1;
+                    } else {
+                        if (type1.isArray() && !type2.isArray()) {
+                            return 1;
+                        }
+                        return -1;
+                    }
+                }
+            }
+            return 0;
+        }
+    }
+}

--- a/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
+++ b/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
@@ -17,7 +17,12 @@ package org.powermock.reflect;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.powermock.reflect.context.*;
+import org.powermock.reflect.context.ClassFieldsNotInTargetContext;
+import org.powermock.reflect.context.InstanceFieldsNotInTargetContext;
+import org.powermock.reflect.context.MyContext;
+import org.powermock.reflect.context.MyIntContext;
+import org.powermock.reflect.context.MyStringContext;
+import org.powermock.reflect.context.OneInstanceAndOneStaticFieldOfSameTypeContext;
 import org.powermock.reflect.exceptions.FieldNotFoundException;
 import org.powermock.reflect.exceptions.MethodNotFoundException;
 import org.powermock.reflect.exceptions.TooManyFieldsFoundException;
@@ -26,7 +31,31 @@ import org.powermock.reflect.internal.WhiteboxImpl;
 import org.powermock.reflect.matching.FieldMatchingStrategy;
 import org.powermock.reflect.proxyframework.RegisterProxyFramework;
 import org.powermock.reflect.spi.ProxyFramework;
-import org.powermock.reflect.testclasses.*;
+import org.powermock.reflect.testclasses.AbstractClass;
+import org.powermock.reflect.testclasses.AnInterface;
+import org.powermock.reflect.testclasses.Child;
+import org.powermock.reflect.testclasses.ClassWithAMethod;
+import org.powermock.reflect.testclasses.ClassWithChildThatHasInternalState;
+import org.powermock.reflect.testclasses.ClassWithInterfaceConstructors;
+import org.powermock.reflect.testclasses.ClassWithInterfaceConstructors.ConstructorInterface;
+import org.powermock.reflect.testclasses.ClassWithInterfaceConstructors.ConstructorInterfaceImpl;
+import org.powermock.reflect.testclasses.ClassWithInternalState;
+import org.powermock.reflect.testclasses.ClassWithList;
+import org.powermock.reflect.testclasses.ClassWithObjectConstructors;
+import org.powermock.reflect.testclasses.ClassWithOverloadedConstructors;
+import org.powermock.reflect.testclasses.ClassWithOverloadedMethods;
+import org.powermock.reflect.testclasses.ClassWithOverriddenMethod;
+import org.powermock.reflect.testclasses.ClassWithPrimitiveConstructors;
+import org.powermock.reflect.testclasses.ClassWithPrivateMethods;
+import org.powermock.reflect.testclasses.ClassWithSerializableState;
+import org.powermock.reflect.testclasses.ClassWithSeveralMethodsWithSameName;
+import org.powermock.reflect.testclasses.ClassWithSeveralMethodsWithSameNameOneWithoutParameters;
+import org.powermock.reflect.testclasses.ClassWithSimpleInternalState;
+import org.powermock.reflect.testclasses.ClassWithStaticAndInstanceInternalStateOfSameType;
+import org.powermock.reflect.testclasses.ClassWithStaticMethod;
+import org.powermock.reflect.testclasses.ClassWithUniquePrivateMethods;
+import org.powermock.reflect.testclasses.ClassWithVarArgsConstructor;
+import org.powermock.reflect.testclasses.ClassWithVarArgsConstructor2;
 
 import java.io.InputStream;
 import java.io.Serializable;
@@ -37,7 +66,13 @@ import java.sql.Connection;
 import java.util.Set;
 
 import static junit.framework.Assert.assertFalse;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests the WhiteBox's functionality.
@@ -861,6 +896,47 @@ public class WhiteBoxTest {
         assertEquals("null null", Whitebox.invokeMethod(ClassWithStaticMethod.class, "anotherStaticMethod", (Object) null, (byte[]) null));
     }
 
+
+    @Test
+    public void testObjectConstructors() throws Exception{
+        String name = "objectConstructor";
+        ClassWithObjectConstructors instance = Whitebox.invokeConstructor(ClassWithObjectConstructors.class,
+                name);
+
+        assertEquals(instance.getName(),name);
+    }
+
+    @Test
+    public void testInterfaceConstructors() throws Exception{
+        ConstructorInterface param = new ConstructorInterfaceImpl("constructorInterfaceSomeValue");
+        ClassWithInterfaceConstructors instance = Whitebox.invokeConstructor(ClassWithInterfaceConstructors.class,
+                param);
+
+        assertEquals(instance.getValue(),param.getValue());
+    }
+
+    @Test
+    public void testPrimitiveConstructorsArgumentBoxed() throws Exception{
+        Long arg = 1L;
+        ClassWithPrimitiveConstructors instance = Whitebox.invokeConstructor(ClassWithPrimitiveConstructors.class,
+                arg);
+
+        assertEquals(instance.getValue(),arg.longValue());
+    }
+
+	@Test
+	public void testOverloadedConstructors() throws Exception{
+        String name = "overloadedConstructor";
+        ClassWithOverloadedConstructors instance = Whitebox.invokeConstructor(ClassWithOverloadedConstructors.class,
+                true, name);
+
+        assertEquals(instance.getName(),name);
+        assertTrue(instance.isBool());
+        assertFalse(instance.isBool1());
+	}
+
+    @Test
+    @Ignore("Reflection and direct call returns different values.")
 	public void testFinalState() {
 		ClassWithInternalState state = new ClassWithInternalState();
 		String expected = "changed";

--- a/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInterfaceConstructors.java
+++ b/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInterfaceConstructors.java
@@ -1,0 +1,31 @@
+package org.powermock.reflect.testclasses;
+
+/**
+ *
+ */
+public class ClassWithInterfaceConstructors {
+
+
+    private final ConstructorInterface constructorInterface;
+
+    public ClassWithInterfaceConstructors(ConstructorInterface constructorInterface) {this.constructorInterface = constructorInterface;}
+
+    public String getValue() {
+        return constructorInterface.getValue();
+    }
+
+    public interface ConstructorInterface {
+        String getValue();
+    }
+
+    public static class ConstructorInterfaceImpl implements ConstructorInterface {
+        private final String value;
+
+        public ConstructorInterfaceImpl(String value) {this.value = value;}
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithObjectConstructors.java
+++ b/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithObjectConstructors.java
@@ -1,0 +1,19 @@
+package org.powermock.reflect.testclasses;
+
+/**
+ *
+ */
+public class ClassWithObjectConstructors {
+
+    private final Object name;
+
+    protected ClassWithObjectConstructors(Object name) {
+
+        this.name = name;
+    }
+
+    public Object getName() {
+        return name;
+    }
+
+}

--- a/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithOverloadedConstructors.java
+++ b/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithOverloadedConstructors.java
@@ -1,0 +1,39 @@
+package org.powermock.reflect.testclasses;
+
+/**
+ *
+ */
+public class ClassWithOverloadedConstructors {
+
+    private final String name;
+    private final boolean bool;
+    private final boolean bool1;
+
+    protected ClassWithOverloadedConstructors(String name) {
+
+        this(name, false, false);
+    }
+
+
+    protected ClassWithOverloadedConstructors(boolean bool, String name) {
+        this(name, bool, false);
+    }
+
+    protected ClassWithOverloadedConstructors(String name, boolean bool, boolean bool1) {
+        this.name = name;
+        this.bool = bool;
+        this.bool1 = bool1;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isBool() {
+        return bool;
+    }
+
+    public boolean isBool1() {
+        return bool1;
+    }
+}

--- a/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithPrimitiveConstructors.java
+++ b/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithPrimitiveConstructors.java
@@ -1,0 +1,18 @@
+package org.powermock.reflect.testclasses;
+
+/**
+ *
+ */
+public class ClassWithPrimitiveConstructors {
+
+    private final long value;
+
+    public ClassWithPrimitiveConstructors(long value){
+
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
It was the issue not with overload constructors, but with constructors with object parameters. Also supper class for arguments has not been checked, for example in this case: 

```
public class ClassWithObjectConstructors {

    private final Object name;

    protected ClassWithObjectConstructors(Object name) {

        this.name = name;
    }

    public Object getName() {
        return name;
    }

}
```

this code threw exception 

        String name = "objectConstructor";
        ClassWithObjectConstructors instance = Whitebox.invokeConstructor(ClassWithObjectConstructors.class,
                name);


Fix #214 