### PR TITLE
TestNG SkipException doesn't work with PowerMock #647

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,8 @@ Change log next version
 * PowerMockRunner now processes JUnit Rules correctly (thanks to Stefan Birkner for pull request) (issue 427)
 * Fix #214: Whitebox.invokeConstructor may not work as expected with overloaded constructors
 * Fix #590: suppress(method) doesn't work on a @Spy/PowerMockito.spy
-* Fix #634/#632: Add workaround as fix  for Mockito 1+. Wait fix from Mockito team for Mockito 2. 
+* Fix #634/#632: Add workaround as fix  for Mockito 1+. Wait fix from Mockito team for Mockito 2.
+* Fix #648: TestNG SkipException doesn't work with PowerMock
 * Added support for @TestSubject in EasyMock API. This is the equivalent of @InjectMocks in Mockito (big thanks to Arthur Zagretdinov for pull request)
 * Added experimental support for mockito 2.x
 * Upgraded commons-logging dependency to version 1.2

--- a/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
+++ b/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
@@ -64,7 +64,8 @@ public class MockClassLoader extends DeferSupportingClassLoader {
      * Classes not deferred but loaded by the mock class loader but they're not
      * modified.
      */
-    private final String[] packagesToLoadButNotModify = new String[]{"org.junit.", "junit.", "org.easymock.",
+    private final String[] packagesToLoadButNotModify = new String[]{"org.junit.", "junit.", "org.testng.",
+            "org.easymock.",
             "net.sf.cglib.", "javassist.",
             "org.powermock.modules.junit4.internal.", "org.powermock.modules.junit4.legacy.internal.",
             "org.powermock.modules.junit3.internal.",
@@ -79,7 +80,7 @@ public class MockClassLoader extends DeferSupportingClassLoader {
      * specifies in annotations etc.
      */
     private static final String[] packagesToBeDeferred = new String[]{"org.hamcrest.*", "java.*",
-            "javax.accessibility.*", "sun.*", "org.junit.*",
+            "javax.accessibility.*", "sun.*", "org.junit.*", "org.testng.*",
             "junit.*", "org.pitest.*", "org.powermock.modules.junit4.common.internal.*",
             "org.powermock.modules.junit3.internal.PowerMockJUnit3RunnerDelegate*",
             "org.powermock.core*", "org.jacoco.agent.rt.*"};

--- a/modules/module-test/pom.xml
+++ b/modules/module-test/pom.xml
@@ -19,5 +19,6 @@
     <modules>
         <module>easymock</module>
         <module>mockito</module>
+        <module>testng</module>
     </modules>
 </project>

--- a/modules/module-test/testng/pom.xml
+++ b/modules/module-test/testng/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>powermock-modules-test</artifactId>
+        <groupId>org.powermock</groupId>
+        <version>1.6.5-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>powermock-modules-test-testng</artifactId>
+    <name>${project.artifactId}</name>
+
+    <description>
+        Tests TestNG.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>suite.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/modules/module-test/testng/src/test/java/org/powermock/api/extension/proxyframework/ProxyFrameworkImpl.java
+++ b/modules/module-test/testng/src/test/java/org/powermock/api/extension/proxyframework/ProxyFrameworkImpl.java
@@ -1,0 +1,18 @@
+package org.powermock.api.extension.proxyframework;
+
+import org.powermock.reflect.spi.ProxyFramework;
+
+/**
+ *
+ */
+public class ProxyFrameworkImpl implements ProxyFramework {
+    @Override
+    public Class<?> getUnproxiedType(Class<?> type) {
+        return type;
+    }
+
+    @Override
+    public boolean isProxy(Class<?> type) {
+        return false;
+    }
+}

--- a/modules/module-test/testng/src/test/java/samples/testng/SimpleBaseTest.java
+++ b/modules/module-test/testng/src/test/java/samples/testng/SimpleBaseTest.java
@@ -1,0 +1,120 @@
+package samples.testng;
+
+import org.testng.Assert;
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.collections.Lists;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class SimpleBaseTest {
+
+    private static final String TEST_RESOURCES_DIR = "test.resources.dir";
+
+    public static TestNG create() {
+        TestNG result = new TestNG();
+        result.setUseDefaultListeners(false);
+        result.setVerbose(0);
+        return result;
+    }
+
+    public static TestNG create(Class<?>... testClasses) {
+        TestNG result = create();
+        result.setTestClasses(testClasses);
+        return result;
+    }
+
+    public static String getPathToResource(String fileName) {
+        String result = System.getProperty(TEST_RESOURCES_DIR);
+        if (result == null) {
+            throw new IllegalArgumentException("System property " + TEST_RESOURCES_DIR + " was not defined.");
+        }
+        return result + File.separatorChar + fileName;
+    }
+
+    /**
+     * Compare a list of ITestResult with a list of String method names,
+     */
+    public static void assertTestResultsEqual(List<ITestResult> results, List<String> methods) {
+        List<String> resultMethods = Lists.newArrayList();
+        for (ITestResult r : results) {
+            resultMethods.add(r.getMethod().getMethodName());
+        }
+        Assert.assertEquals(resultMethods, methods);
+    }
+
+    protected TestNG create(XmlSuite... suites) {
+        TestNG result = create();
+        result.setXmlSuites(Arrays.asList(suites));
+        return result;
+    }
+
+    protected TestNG createTests(String suiteName, Class<?>... testClasses) {
+        XmlSuite suite = createXmlSuite(suiteName);
+        int i = 0;
+        for (Class<?> testClass : testClasses) {
+            createXmlTest(suite, testClass.getName() + i, testClass);
+            i++;
+        }
+        return create(suite);
+    }
+
+    protected XmlSuite createXmlSuite(String name) {
+        XmlSuite result = new XmlSuite();
+        result.setName(name);
+        return result;
+    }
+
+    protected XmlTest createXmlTest(XmlSuite suite, String name, Class clazz, Class... classes) {
+        XmlTest result = new XmlTest(suite);
+        int index = 0;
+        result.setName(name);
+        XmlClass xc = new XmlClass(clazz.getName(), index++, true /* load classes */);
+        result.getXmlClasses().add(xc);
+        for (Class c : classes) {
+            xc = new XmlClass(c.getName(), index++, true /* load classes */);
+            result.getXmlClasses().add(xc);
+        }
+
+        return result;
+    }
+
+    protected XmlTest createXmlTest(XmlSuite suite, String name, String... classes) {
+        XmlTest result = new XmlTest(suite);
+        int index = 0;
+        result.setName(name);
+        for (String c : classes) {
+            XmlClass xc = new XmlClass(c, index++, true /* load classes */);
+            result.getXmlClasses().add(xc);
+        }
+
+        return result;
+    }
+
+    protected void addMethods(XmlClass cls, String... methods) {
+        int index = 0;
+        for (String m : methods) {
+            XmlInclude include = new XmlInclude(m, index++);
+            cls.getIncludedMethods().add(include);
+        }
+    }
+
+    protected void verifyPassedTests(TestListenerAdapter tla, String... methodNames) {
+        Iterator<ITestResult> it = tla.getPassedTests().iterator();
+        Assert.assertEquals(tla.getPassedTests().size(), methodNames.length);
+
+        int i = 0;
+        while (it.hasNext()) {
+            Assert.assertEquals(it.next().getName(), methodNames[i++]);
+        }
+    }
+
+}

--- a/modules/module-test/testng/src/test/java/samples/testng/powermock647/PowerMock647.java
+++ b/modules/module-test/testng/src/test/java/samples/testng/powermock647/PowerMock647.java
@@ -1,0 +1,93 @@
+package samples.testng.powermock647;
+
+import org.testng.IResultMap;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import samples.testng.SimpleBaseTest;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.testng.Assert.assertEquals;
+
+public class PowerMock647 extends SimpleBaseTest {
+
+  private final TestListenerAdapter tla;
+
+  public PowerMock647() {
+    tla = new TestListenerAdapter();
+  }
+
+  @Test
+  public void testSkipTest() throws Exception {
+
+    final TestNG tng = createTestNG();
+
+    runTest(tng);
+
+    assertOneTestSkipped();
+  }
+
+  private TestNG createTestNG() {
+    final TestNG tng = create(SkipExceptionTest.class);
+    tng.setThreadCount(1);
+    tng.setParallel(XmlSuite.ParallelMode.NONE);
+    tng.setPreserveOrder(true);
+    tng.addListener(tla);
+    return tng;
+  }
+
+  private void assertOneTestSkipped() {
+    IResultMap skippedTests = tla.getTestContexts().get(0).getSkippedTests();
+    assertEquals(1, skippedTests.size());
+  }
+
+  private void runTest(TestNG tng) {
+
+    ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+    ClassLoader classLoader = new SimpleClassLoader(currentClassLoader);
+
+    Thread.currentThread().setContextClassLoader(classLoader);
+
+    tng.run();
+
+    Thread.currentThread().setContextClassLoader(currentClassLoader);
+  }
+
+  public static final class SimpleClassLoader extends ClassLoader {
+
+    private final ClassLoader currentClassLoader;
+    private final URLClassLoader delegate;
+
+    public SimpleClassLoader(ClassLoader currentClassLoader) {
+      this.currentClassLoader = currentClassLoader;
+      this.delegate = new URLClassLoader(new URL[]{currentClassLoader.getResource("")}, null);
+    }
+
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+      final Class<?> clazz;
+
+      if (shouldBeLoadedWithDelegate(name)) {
+        clazz = delegate.loadClass(name);
+      } else {
+        clazz = currentClassLoader.loadClass(name);
+      }
+
+      if (resolve) {
+        resolveClass(clazz);
+      }
+
+      return clazz;
+    }
+
+    private boolean shouldBeLoadedWithDelegate(String name) {
+      return "org.testng.SkipException".equals(name) || "test.testng1003.SkipExceptionTest".equals(name) ||
+                 "test.testng1003.SomeClass".equals(name);
+    }
+
+  }
+}

--- a/modules/module-test/testng/src/test/java/samples/testng/powermock647/SkipExceptionTest.java
+++ b/modules/module-test/testng/src/test/java/samples/testng/powermock647/SkipExceptionTest.java
@@ -1,0 +1,17 @@
+package samples.testng.powermock647;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.Test;
+
+/**
+ *
+ */
+@PrepareForTest(SomeClass.class)
+public class SkipExceptionTest extends PowerMockTestCase{
+
+    @Test
+    public void testSkipException() throws Throwable {
+        new SomeClass().throwSkipException();
+    }
+}

--- a/modules/module-test/testng/src/test/java/samples/testng/powermock647/SomeClass.java
+++ b/modules/module-test/testng/src/test/java/samples/testng/powermock647/SomeClass.java
@@ -1,0 +1,12 @@
+package samples.testng.powermock647;
+
+import org.testng.SkipException;
+
+/**
+ *
+ */
+public class SomeClass {
+    public void throwSkipException() {
+        throw new SkipException("Skip test");
+    }
+}

--- a/modules/module-test/testng/suite.xml
+++ b/modules/module-test/testng/suite.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="TestNG" verbose="10" object-factory="org.powermock.modules.testng.PowerMockObjectFactory">
+    <test name="TestNG Skip test Bug #647">
+        <classes>
+            <class name="samples.testng.powermock647.PowerMock647"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Add "org.testng.*" package to list of packaged which should always be deferred. 