### PR TITLE
Fix #652 PowerMock stubbing void method don't work for overloaded methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Change log next version
 * Fix #590: suppress(method) doesn't work on a @Spy/PowerMockito.spy
 * Fix #634/#632: Add workaround as fix  for Mockito 1+. Wait fix from Mockito team for Mockito 2.
 * Fix #648: TestNG SkipException doesn't work with PowerMock
+* Fix #652: PowerMock stubbing void method don't work for overloaded methods
 * Added support for @TestSubject in EasyMock API. This is the equivalent of @InjectMocks in Mockito (big thanks to Arthur Zagretdinov for pull request)
 * Added experimental support for mockito 2.x
 * Upgraded commons-logging dependency to version 1.2

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/staticmocking/MockStaticTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/staticmocking/MockStaticTest.java
@@ -26,12 +26,15 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import samples.singleton.SimpleStaticService;
 import samples.singleton.StaticService;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
@@ -209,4 +212,17 @@ public class MockStaticTest {
 
         assertEquals("something", captor.getValue());
     }
+
+	@Test
+	public void testMockStaticWithExpectations_withDo() throws Exception {
+		final String argument = "hello";
+
+		mockStatic(StaticService.class);
+
+		doNothing().when(StaticService.class,"sayHello",any(String.class));
+
+		StaticService.sayHello(argument);
+
+		assertThat(StaticService.messageStorage).isNull();
+	}
 }

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -19,4 +19,12 @@
         <module>module-impl</module>
         <module>module-test</module>
     </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/reflect/src/main/java/org/powermock/reflect/internal/ParameterTypesMatcher.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/ParameterTypesMatcher.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.reflect.internal;
+
+/**
+ *
+ */
+class ParameterTypesMatcher {
+    private boolean isVarArgs;
+    private Class<?>[] expectedParameterTypes;
+    private Class<?>[] actualParameterTypes;
+
+    public ParameterTypesMatcher(boolean isVarArgs, Class<?>[] expectedParameterTypes, Class<?>... actualParameterTypes) {
+        this.isVarArgs = isVarArgs;
+        this.expectedParameterTypes = expectedParameterTypes;
+        this.actualParameterTypes = actualParameterTypes;
+    }
+
+    private boolean isRemainParamsVarArgs(int index, Class<?> actualParameterType) {
+        return isVarArgs && index == expectedParameterTypes.length - 1
+                       && actualParameterType.getComponentType().isAssignableFrom(expectedParameterTypes[index]);
+    }
+
+    private boolean isParameterTypesNotMatch(Class<?> actualParameterType, Class<?> expectedParameterType) {
+        if (actualParameterType == null){
+            return false;
+        }
+        if (expectedParameterType == null){
+           return false;
+        }
+        return !actualParameterType.isAssignableFrom(expectedParameterType);
+    }
+
+    public boolean match() {
+        assertParametersTypesNotNull();
+        if (isParametersLengthMatch()) {
+            return false;
+        } else {
+            return isParametersMatch();
+        }
+    }
+
+    private boolean isParametersLengthMatch() {return expectedParameterTypes.length != actualParameterTypes.length;}
+
+    private void assertParametersTypesNotNull() {
+        if (expectedParameterTypes == null || actualParameterTypes == null) {
+            throw new IllegalArgumentException("parameter types cannot be null");
+        }
+    }
+
+    private Boolean isParametersMatch() {
+        for (int index = 0; index < expectedParameterTypes.length; index++) {
+            final Class<?> actualParameterType = WhiteboxImpl.getType(actualParameterTypes[index]);
+            if (isRemainParamsVarArgs(index, actualParameterType)) {
+                return true;
+            } else {
+                final Class<?> expectedParameterType = expectedParameterTypes[index];
+                if (isParameterTypesNotMatch(actualParameterType, expectedParameterType)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -1165,7 +1165,8 @@ public class WhiteboxImpl {
                 methodNameData = "with name '" + methodName + "' ";
             }
             throw new MethodNotFoundException("No method found " + methodNameData + "with parameter types: [ "
-                                                      + getArgumentTypesAsString(arguments) + " ] in class " + getUnmockedType(type).getName() + ".");
+                                                      + getArgumentTypesAsString(arguments) + " ] in class " + getUnmockedType(type)
+                                                                                                                       .getName() + ".");
         }
     }
 
@@ -1737,7 +1738,7 @@ public class WhiteboxImpl {
         StringBuilder sb = new StringBuilder();
         sb.append("Several matching constructors found, please specify the argument parameter types so that PowerMock can determine which method you're referring to.\n");
         sb.append("Matching constructors in class ").append(constructors[0].getDeclaringClass().getName())
-                .append(" were:\n");
+          .append(" were:\n");
 
         for (Constructor<?> constructor : constructors) {
             sb.append(constructor.getName()).append("( ");
@@ -2269,22 +2270,7 @@ public class WhiteboxImpl {
      */
     public static boolean checkIfParameterTypesAreSame(boolean isVarArgs, Class<?>[] expectedParameterTypes,
                                                        Class<?>[] actualParameterTypes) {
-        if (expectedParameterTypes == null || actualParameterTypes == null) {
-            throw new IllegalArgumentException("parameter types cannot be null");
-        } else if (expectedParameterTypes.length != actualParameterTypes.length) {
-            return false;
-        } else {
-            for (int i = 0; i < expectedParameterTypes.length; i++) {
-                final Class<?> actualParameterType = getType(actualParameterTypes[i]);
-                if (isVarArgs && i == expectedParameterTypes.length - 1
-                            && actualParameterType.getComponentType().isAssignableFrom(expectedParameterTypes[i])) {
-                    return true;
-                } else if (!actualParameterType.isAssignableFrom(expectedParameterTypes[i])) {
-                    return false;
-                }
-            }
-        }
-        return true;
+        return new ParameterTypesMatcher(isVarArgs, expectedParameterTypes, actualParameterTypes).match();
     }
 
     /**

--- a/tests/utils/src/main/java/samples/singleton/StaticService.java
+++ b/tests/utils/src/main/java/samples/singleton/StaticService.java
@@ -27,7 +27,18 @@ import java.util.concurrent.Callable;
 public class StaticService {
 
 	private static int number = 17;
-	private int secret = 23;
+    private static Integer intValue;
+    public static String messageStorage;
+
+    private int secret = 23;
+
+    public static void sayHello(String message) {
+        messageStorage = message;
+    }
+
+    public static void sayHello(Integer intValue) {
+        StaticService.intValue = intValue;
+    }
 
 	public static int getNumberFromInner() {
 		return new Callable<Integer>() {


### PR DESCRIPTION
Fix #652 PowerMock stubbing void method don't work for overloaded methods