### PR TITLE
Fix #510 and other issue with interface with java8

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Change log next version
 * Fix #634/#632: Add workaround as fix  for Mockito 1+. Wait fix from Mockito team for Mockito 2.
 * Fix #648: TestNG SkipException doesn't work with PowerMock
 * Fix #652: PowerMock stubbing void method don't work for overloaded methods
+* Fix #510: Static method mocking with Mockito 1.9.5 and Powermock fails with Java 8 Consumer Interface
 * Added support for @TestSubject in EasyMock API. This is the equivalent of @InjectMocks in Mockito (big thanks to Arthur Zagretdinov for pull request)
 * Added experimental support for mockito 2.x
 * Upgraded commons-logging dependency to version 1.2

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,5 +54,11 @@
             <version>3.20.0-GA</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/org/powermock/core/transformers/MockTransformer.java
+++ b/core/src/main/java/org/powermock/core/transformers/MockTransformer.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2011 the original author or authors.
+ *   Copyright 2016 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
  */
 package org.powermock.core.transformers;
 
@@ -27,11 +28,10 @@ import javassist.CtClass;
 public interface MockTransformer {
 
 	/**
-	 * Transforms the <code>Class</code> with name
-	 * <code>fullyQualifiedName</code>.
+	 * Transforms the <code>clazz</code>.
 	 * 
-	 * @param fullyQualifiedName
-	 *            The fully qualified name of the <code>Class</code> to
+	 * @param clazz
+	 *            The class to be
 	 *            transform into a mock enabled class.
 	 * @return A <code>CtClass</code> representation of the mocked class.
 	 */

--- a/core/src/main/java/org/powermock/core/transformers/impl/ClassMockTransformer.java
+++ b/core/src/main/java/org/powermock/core/transformers/impl/ClassMockTransformer.java
@@ -1,0 +1,71 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.powermock.core.transformers.impl;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+import org.powermock.core.transformers.TransformStrategy;
+
+import static org.powermock.core.transformers.TransformStrategy.CLASSLOADER;
+import static org.powermock.core.transformers.TransformStrategy.INST_TRANSFORM;
+
+public class ClassMockTransformer extends AbstractMainMockTransformer {
+
+    public ClassMockTransformer() {
+        this(CLASSLOADER);
+    }
+
+    public ClassMockTransformer(TransformStrategy strategy) {
+        super(strategy);
+    }
+
+    @Override
+    protected CtClass transformMockClass(CtClass clazz) throws CannotCompileException, NotFoundException {
+        if (clazz.isInterface()) {
+            return clazz;
+        }
+
+        /*
+        * Set class modifier to public to allow for mocking of package private
+        * classes. This is needed because we've changed to CgLib naming policy
+        * to allow for mocking of signed classes.
+        */
+
+        final String name = allowMockingOfPackagePrivateClasses(clazz);
+
+        suppressStaticInitializerIfRequested(clazz, name);
+
+        // This should probably be configurable
+        removeFinalModifierFromClass(clazz);
+
+        allowMockingOfStaticAndFinalAndNativeMethods(clazz);
+
+        // Convert all constructors to public
+        setAllConstructorsToPublic(clazz);
+
+        // Remove final from all static final fields. Not possible if using a java agent.
+        removeFinalModifierFromAllStaticFinalFields(clazz);
+
+        if (strategy != INST_TRANSFORM) {
+            clazz.instrument(new PowerMockExpressionEditor(clazz));
+        }
+
+        return clazz;
+    }
+
+}

--- a/core/src/main/java/org/powermock/core/transformers/impl/InterfaceMockTransformer.java
+++ b/core/src/main/java/org/powermock/core/transformers/impl/InterfaceMockTransformer.java
@@ -1,0 +1,60 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.core.transformers.impl;
+
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.NotFoundException;
+import org.powermock.core.transformers.TransformStrategy;
+
+import static org.powermock.core.transformers.TransformStrategy.CLASSLOADER;
+
+/**
+ *
+ */
+public class InterfaceMockTransformer extends AbstractMainMockTransformer {
+
+    public InterfaceMockTransformer() {
+        this(CLASSLOADER);
+    }
+
+    public InterfaceMockTransformer(TransformStrategy strategy) {
+        super(strategy);
+    }
+
+    @Override
+    protected CtClass transformMockClass(CtClass clazz) throws CannotCompileException, NotFoundException {
+        if (!clazz.isInterface()) {
+            return clazz;
+        }
+
+        /*
+        * Set class modifier to public to allow for mocking of package private
+        * classes. This is needed because we've changed to CgLib naming policy
+        * to allow for mocking of signed classes.
+        */
+
+        final String name = allowMockingOfPackagePrivateClasses(clazz);
+
+        suppressStaticInitializerIfRequested(clazz, name);
+
+        allowMockingOfStaticAndFinalAndNativeMethods(clazz);
+
+        return clazz;
+    }
+}

--- a/core/src/main/java/org/powermock/core/transformers/impl/TestClassTransformer.java
+++ b/core/src/main/java/org/powermock/core/transformers/impl/TestClassTransformer.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2013 the original author or authors.
+ *   Copyright 2016 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
  */
 package org.powermock.core.transformers.impl;
 
@@ -43,7 +44,7 @@ import org.powermock.core.transformers.MockTransformer;
  * chunking!
  * 3) Restore original test-class constructors` accesses
  * (in case they have all been made public by {@link
- * MainMockTransformer#setAllConstructorsToPublic(javassist.CtClass)})
+ * ClassMockTransformer#setAllConstructorsToPublic(javassist.CtClass)})
  * - to avoid that multiple <i>public</i> test-class constructors cause
  * a delegate runner from JUnit (or 3rd party) to bail out with an
  * error message such as "Test class can only have one constructor".

--- a/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestSuiteChunkerImpl.java
+++ b/core/src/main/java/org/powermock/tests/utils/impl/AbstractTestSuiteChunkerImpl.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2011 the original author or authors.
+ *   Copyright 2016 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
  */
 package org.powermock.tests.utils.impl;
 
@@ -27,7 +28,8 @@ import org.powermock.core.reporter.MockingFrameworkReporterFactory;
 import org.powermock.core.spi.PowerMockPolicy;
 import org.powermock.core.spi.PowerMockTestListener;
 import org.powermock.core.transformers.MockTransformer;
-import org.powermock.core.transformers.impl.MainMockTransformer;
+import org.powermock.core.transformers.impl.ClassMockTransformer;
+import org.powermock.core.transformers.impl.InterfaceMockTransformer;
 import org.powermock.core.transformers.impl.TestClassTransformer;
 import org.powermock.reflect.Whitebox;
 import org.powermock.reflect.proxyframework.RegisterProxyFramework;
@@ -237,10 +239,7 @@ public abstract class AbstractTestSuiteChunkerImpl<T> implements TestSuiteChunke
         if ((classesToLoadByMockClassloader == null || classesToLoadByMockClassloader.length == 0) && !hasMockPolicyProvidedClasses(testClass)) {
             mockLoader = Thread.currentThread().getContextClassLoader();
         } else {
-            List<MockTransformer> mockTransformerChain = new ArrayList<MockTransformer>();
-            final MainMockTransformer mainMockTransformer = new MainMockTransformer();
-            mockTransformerChain.add(mainMockTransformer);
-            Collections.addAll(mockTransformerChain, extraMockTransformers);
+            List<MockTransformer> mockTransformerChain = getMockTransformers(extraMockTransformers);
             final UseClassPathAdjuster useClassPathAdjuster = testClass.getAnnotation(UseClassPathAdjuster.class);
             mockLoader = AccessController.doPrivileged(new PrivilegedAction<MockClassLoader>() {
                 @Override
@@ -253,6 +252,16 @@ public abstract class AbstractTestSuiteChunkerImpl<T> implements TestSuiteChunke
             new MockPolicyInitializerImpl(testClass).initialize(mockLoader);
         }
         return mockLoader;
+    }
+
+    protected List<MockTransformer> getMockTransformers(MockTransformer[] extraMockTransformers) {
+        List<MockTransformer> mockTransformerChain = new ArrayList<MockTransformer>();
+
+        mockTransformerChain.add(new ClassMockTransformer());
+        mockTransformerChain.add(new InterfaceMockTransformer());
+
+        Collections.addAll(mockTransformerChain, extraMockTransformers);
+        return mockTransformerChain;
     }
 
     /**

--- a/core/src/test/java/org/powermock/core/classloader/MockClassLoaderTest.java
+++ b/core/src/test/java/org/powermock/core/classloader/MockClassLoaderTest.java
@@ -22,7 +22,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.UseClassPathAdjuster;
 import org.powermock.core.transformers.MockTransformer;
-import org.powermock.core.transformers.impl.MainMockTransformer;
+import org.powermock.core.transformers.impl.ClassMockTransformer;
 import org.powermock.reflect.Whitebox;
 
 import java.lang.annotation.Annotation;
@@ -40,7 +40,7 @@ public class MockClassLoaderTest {
         String name = this.getClass().getPackage().getName() + ".HardToTransform";
         final MockClassLoader mockClassLoader = new MockClassLoader(new String[]{name});
         List<MockTransformer> list = new LinkedList<MockTransformer>();
-        list.add(new MainMockTransformer());
+        list.add(new ClassMockTransformer());
         mockClassLoader.setMockTransformerChain(list);
         Class<?> c = mockClassLoader.loadClass(name);
 
@@ -103,7 +103,7 @@ public class MockClassLoaderTest {
     public void canFindResource() throws Exception {
         final MockClassLoader mockClassLoader = new MockClassLoader(new String[0]);
         List<MockTransformer> list = new LinkedList<MockTransformer>();
-        list.add(new MainMockTransformer());
+        list.add(new ClassMockTransformer());
         mockClassLoader.setMockTransformerChain(list);
 
         // Force a ClassLoader that can find 'foo/bar/baz/test.txt' into
@@ -123,7 +123,7 @@ public class MockClassLoaderTest {
     public void canFindResources() throws Exception {
         final MockClassLoader mockClassLoader = new MockClassLoader(new String[0]);
         List<MockTransformer> list = new LinkedList<MockTransformer>();
-        list.add(new MainMockTransformer());
+        list.add(new ClassMockTransformer());
         mockClassLoader.setMockTransformerChain(list);
 
         // Force a ClassLoader that can find 'foo/bar/baz/test.txt' into
@@ -146,7 +146,7 @@ public class MockClassLoaderTest {
     public void resourcesNotDoubled() throws Exception {
         final MockClassLoader mockClassLoader = new MockClassLoader(new String[0]);
         List<MockTransformer> list = new LinkedList<MockTransformer>();
-        list.add(new MainMockTransformer());
+        list.add(new ClassMockTransformer());
         mockClassLoader.setMockTransformerChain(list);
 
         // MockClassLoader will only be able to find 'foo/bar/baz/test.txt' if it
@@ -175,7 +175,7 @@ public class MockClassLoaderTest {
         };
         final MockClassLoader mockClassLoader = new MockClassLoader(new String[0], useClassPathAdjuster);
         List<MockTransformer> list = new LinkedList<MockTransformer>();
-        list.add(new MainMockTransformer());
+        list.add(new ClassMockTransformer());
         mockClassLoader.setMockTransformerChain(list);
 
         // setup custom classloader providing our dynamic class, for MockClassLoader to defer to
@@ -203,7 +203,7 @@ public class MockClassLoaderTest {
 
         MockClassLoader mockClassLoader = new MockClassLoader(new String[0]);
         List<MockTransformer> list = new LinkedList<MockTransformer>();
-        list.add(new MainMockTransformer());
+        list.add(new ClassMockTransformer());
         mockClassLoader.setMockTransformerChain(list);
 
         // setup custom classloader providing our dynamic class, for MockClassLoader to defer to

--- a/core/src/test/java/org/powermock/core/transformers/impl/ClassMockTransformerTest.java
+++ b/core/src/test/java/org/powermock/core/transformers/impl/ClassMockTransformerTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-public class MainMockTransformerTest {
+public class ClassMockTransformerTest {
     /**
      * This tests that a inner 'public static final class' can be modified to drop the final modifier. Fixes <a
      * href="http://code.google.com/p/powermock/issues/detail?id=95">Issue 95</a>.
@@ -37,7 +37,7 @@ public class MainMockTransformerTest {
     @Test
     public void staticFinalInnerClassesShouldBecomeNonFinal() throws Exception {
         MockClassLoader mockClassLoader = new MockClassLoader(new String[] { MockClassLoader.MODIFY_ALL_CLASSES });
-        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new MainMockTransformer()));
+        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new ClassMockTransformer()));
         Class<?> clazz = Class.forName(SupportClasses.StaticFinalInnerClass.class.getName(), true, mockClassLoader);
         assertFalse(Modifier.isFinal(clazz.getModifiers()));
     }
@@ -49,7 +49,7 @@ public class MainMockTransformerTest {
     @Test
     public void finalInnerClassesShouldBecomeNonFinal() throws Exception {
         MockClassLoader mockClassLoader = new MockClassLoader(new String[] { MockClassLoader.MODIFY_ALL_CLASSES });
-        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new MainMockTransformer()));
+        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new ClassMockTransformer()));
         Class<?> clazz = Class.forName(SupportClasses.FinalInnerClass.class.getName(), true, mockClassLoader);
         assertFalse(Modifier.isFinal(clazz.getModifiers()));
     }
@@ -61,7 +61,7 @@ public class MainMockTransformerTest {
     @Test
     public void enumClassesShouldBecomeNonFinal() throws Exception {
         MockClassLoader mockClassLoader = new MockClassLoader(new String[] { MockClassLoader.MODIFY_ALL_CLASSES });
-        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new MainMockTransformer()));
+        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new ClassMockTransformer()));
         Class<?> clazz = Class.forName(SupportClasses.EnumClass.class.getName(), true, mockClassLoader);
         assertFalse(Modifier.isFinal(clazz.getModifiers()));
     }
@@ -69,7 +69,7 @@ public class MainMockTransformerTest {
     @Test
     public void privateInnerClassesShouldBecomeNonFinal() throws Exception {
         MockClassLoader mockClassLoader = new MockClassLoader(new String[] { MockClassLoader.MODIFY_ALL_CLASSES });
-        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new MainMockTransformer()));
+        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new ClassMockTransformer()));
         final Class<?> clazz = Class.forName(SupportClasses.class.getName() + "$PrivateStaticFinalInnerClass", true, mockClassLoader);
         assertFalse(Modifier.isFinal(clazz.getModifiers()));
     }
@@ -77,7 +77,7 @@ public class MainMockTransformerTest {
     @Test
     public void subclassShouldNormallyGetAnAdditionalDeferConstructor() throws Exception {
         MockClassLoader mockClassLoader = new MockClassLoader(new String[] { MockClassLoader.MODIFY_ALL_CLASSES });
-        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new MainMockTransformer()));
+        mockClassLoader.setMockTransformerChain(Collections.<MockTransformer> singletonList(new ClassMockTransformer()));
         final Class<?> clazz = Class.forName(SupportClasses.SubClass.class.getName(), true, mockClassLoader);
         assertEquals("Original number of constructoprs",
                 1, SupportClasses.SubClass.class.getConstructors().length);

--- a/core/src/test/java/org/powermock/core/transformers/impl/TestClassTransformerTest.java
+++ b/core/src/test/java/org/powermock/core/transformers/impl/TestClassTransformerTest.java
@@ -122,7 +122,7 @@ public class TestClassTransformerTest {
             MockClassLoader mockClassLoader =
                     new MockClassLoader(preparations(prepare4test));
             mockClassLoader.setMockTransformerChain(Arrays.asList(
-                    new MainMockTransformer(),
+                    new ClassMockTransformer(),
                     testClassTransformer));
             return mockClassLoader;
         }

--- a/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
+++ b/core/src/test/java/powermock/test/support/MainMockTransformerTestSupport.java
@@ -17,9 +17,10 @@
 package powermock.test.support;
 
 import org.powermock.core.classloader.MockClassLoader;
+import org.powermock.core.transformers.impl.ClassMockTransformerTest;
 
 /**
- * This class is used when running tests in {@link org.powermock.core.transformers.impl.MainMockTransformerTest}. It is
+ * This class is used when running tests in {@link ClassMockTransformerTest}. It is
  * placed in this package because classes in org.powermock.core.* are deferred by:
  * {@link MockClassLoader#packagesToBeDeferred}. Additionally, the class must be modified when it is loaded, and as such
  * not in {@link MockClassLoader#packagesToLoadButNotModify}.

--- a/modules/module-impl/agent/src/main/java/org/powermock/modules/agent/PowerMockClassTransformer.java
+++ b/modules/module-impl/agent/src/main/java/org/powermock/modules/agent/PowerMockClassTransformer.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2011 the original author or authors.
+ *   Copyright 2016 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
  */
 
 package org.powermock.modules.agent;
@@ -20,7 +21,7 @@ import javassist.ClassPool;
 import javassist.CtClass;
 import org.powermock.core.agent.JavaAgentClassRegister;
 import org.powermock.core.transformers.TransformStrategy;
-import org.powermock.core.transformers.impl.MainMockTransformer;
+import org.powermock.core.transformers.impl.ClassMockTransformer;
 
 import java.io.ByteArrayInputStream;
 import java.lang.instrument.ClassFileTransformer;
@@ -43,7 +44,7 @@ class PowerMockClassTransformer extends AbstractClassTransformer implements Clas
         this.javaAgentClassRegister = javaAgentClassRegister;
     }
 
-    private static final MainMockTransformer mainMockTransformer = new MainMockTransformer(TransformStrategy.INST_REDEFINE);
+    private static final ClassMockTransformer CLASS_MOCK_TRANSFORMER = new ClassMockTransformer(TransformStrategy.INST_REDEFINE);
 
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
         if (loader == null || shouldIgnore(className)) {
@@ -60,7 +61,7 @@ class PowerMockClassTransformer extends AbstractClassTransformer implements Clas
                     is.close();
                 }
                 
-                ctClass = mainMockTransformer.transform(ctClass);
+                ctClass = CLASS_MOCK_TRANSFORMER.transform(ctClass);
 
                 /*
                  * ClassPool may cause huge memory consumption if the number of CtClass

--- a/modules/module-impl/junit4-rule/src/main/java/org/powermock/modules/junit4/rule/PowerMockClassloaderExecutor.java
+++ b/modules/module-impl/junit4-rule/src/main/java/org/powermock/modules/junit4/rule/PowerMockClassloaderExecutor.java
@@ -19,7 +19,8 @@ package org.powermock.modules.junit4.rule;
 import org.powermock.classloading.ClassloaderExecutor;
 import org.powermock.core.classloader.MockClassLoader;
 import org.powermock.core.transformers.MockTransformer;
-import org.powermock.core.transformers.impl.MainMockTransformer;
+import org.powermock.core.transformers.impl.ClassMockTransformer;
+import org.powermock.core.transformers.impl.InterfaceMockTransformer;
 import org.powermock.reflect.proxyframework.ClassLoaderRegisterProxyFramework;
 import org.powermock.tests.utils.MockPolicyInitializer;
 import org.powermock.tests.utils.impl.PowerMockIgnorePackagesExtractorImpl;
@@ -33,8 +34,8 @@ public class PowerMockClassloaderExecutor {
 
     public static ClassloaderExecutor forClass(Class<?> testClass, MockPolicyInitializer mockPolicyInitializer) {
         List<MockTransformer> mockTransformerChain = new ArrayList<MockTransformer>();
-        final MainMockTransformer mainMockTransformer = new MainMockTransformer();
-        mockTransformerChain.add(mainMockTransformer);
+        mockTransformerChain.add(new ClassMockTransformer());
+        mockTransformerChain.add(new InterfaceMockTransformer());
     
         String[] classesToLoadByMockClassloader = new String[0];
         String[] packagesToIgnore = new String[0];

--- a/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/ClassLoaderFactory.java
+++ b/modules/module-impl/testng/src/main/java/org/powermock/modules/testng/internal/ClassLoaderFactory.java
@@ -19,13 +19,15 @@ package org.powermock.modules.testng.internal;
 
 import org.powermock.core.classloader.MockClassLoaderBuilders;
 import org.powermock.core.transformers.MockTransformer;
-import org.powermock.core.transformers.impl.MainMockTransformer;
+import org.powermock.core.transformers.impl.ClassMockTransformer;
+import org.powermock.core.transformers.impl.InterfaceMockTransformer;
 import org.powermock.tests.utils.IgnorePackagesExtractor;
 import org.powermock.tests.utils.TestClassesExtractor;
 import org.powermock.tests.utils.impl.PowerMockIgnorePackagesExtractorImpl;
 import org.powermock.tests.utils.impl.PrepareForTestExtractorImpl;
 import org.powermock.tests.utils.impl.StaticConstructorSuppressExtractorImpl;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,8 +49,17 @@ class ClassLoaderFactory {
         expectedExceptionsExtractor = new PowerMockExpectedExceptionsExtractorImpl();
         staticConstructorSuppressExtractor = new StaticConstructorSuppressExtractorImpl();
 
-        mockTransformerChain = Collections.singletonList((MockTransformer) new MainMockTransformer());
+        mockTransformerChain = getMockTransformers();
 
+    }
+
+    private List<MockTransformer> getMockTransformers() {
+        List<MockTransformer> mockTransformerChain = new ArrayList<MockTransformer>();
+
+        mockTransformerChain.add(new ClassMockTransformer());
+        mockTransformerChain.add(new InterfaceMockTransformer());
+
+        return mockTransformerChain;
     }
 
     ClassLoader createClassLoader(Class<?> testClass) {

--- a/modules/module-test/mockito/junit4-java8/pom.xml
+++ b/modules/module-test/mockito/junit4-java8/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>powermock-modules-test-mockito</artifactId>
+        <groupId>org.powermock</groupId>
+        <version>1.6.5-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>powermock-module-test-mockito-junit4-java8</artifactId>
+    <name>${project.artifactId}</name>
+
+    <description>
+        Tests for Mockito module with JUnit 4.x. and Java8.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/module-test/mockito/junit4-java8/src/main/java/samples/powermockito/junit4/bugs/github510/ClassUsesInterface.java
+++ b/modules/module-test/mockito/junit4-java8/src/main/java/samples/powermockito/junit4/bugs/github510/ClassUsesInterface.java
@@ -1,0 +1,12 @@
+package samples.powermockito.junit4.bugs.github510;
+
+/**
+ *
+ */
+public class ClassUsesInterface {
+
+    public String saySomething(){
+        return InterfaceWithStatic.sayHello();
+    }
+
+}

--- a/modules/module-test/mockito/junit4-java8/src/main/java/samples/powermockito/junit4/bugs/github510/FizzBuzz.java
+++ b/modules/module-test/mockito/junit4-java8/src/main/java/samples/powermockito/junit4/bugs/github510/FizzBuzz.java
@@ -1,0 +1,31 @@
+package samples.powermockito.junit4.bugs.github510;
+
+import java.io.PrintStream;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
+
+/**
+ *
+ */
+public class FizzBuzz implements IntConsumer {
+
+    private final PrintStream outputStream;
+
+    public FizzBuzz(PrintStream outputStream) {
+
+        this.outputStream = outputStream;
+    }
+
+    public static boolean isFizz(int i) {
+        return i % 5 == 0;
+    }
+
+    public static void run(PrintStream outputStream, int max) {
+        IntStream.range(0, max).forEach(new FizzBuzz(outputStream));
+    }
+
+    @Override
+    public void accept(int value) {
+        outputStream.println("fizz");
+    }
+}

--- a/modules/module-test/mockito/junit4-java8/src/main/java/samples/powermockito/junit4/bugs/github510/InterfaceWithStatic.java
+++ b/modules/module-test/mockito/junit4-java8/src/main/java/samples/powermockito/junit4/bugs/github510/InterfaceWithStatic.java
@@ -1,0 +1,12 @@
+package samples.powermockito.junit4.bugs.github510;
+
+/**
+ *
+ */
+public interface InterfaceWithStatic {
+
+    static String sayHello(){
+        return "What's up?";
+    }
+
+}

--- a/modules/module-test/mockito/junit4-java8/src/test/java/samples/powermockito/junit4/bugs/github510/ClassUsesInterfaceTest.java
+++ b/modules/module-test/mockito/junit4-java8/src/test/java/samples/powermockito/junit4/bugs/github510/ClassUsesInterfaceTest.java
@@ -1,0 +1,38 @@
+package samples.powermockito.junit4.bugs.github510;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(InterfaceWithStatic.class)
+public class ClassUsesInterfaceTest {
+
+    public ClassUsesInterface classUsesInterface;
+
+    @Before
+    public void setUp() throws Exception {
+        classUsesInterface = new ClassUsesInterface();
+
+        mockStatic(InterfaceWithStatic.class);
+    }
+
+
+
+    @Test
+    public void testSaySomething() throws Exception {
+        final String value = "Hi Man";
+        when(InterfaceWithStatic.sayHello()).thenReturn(value);
+
+        assertThat(classUsesInterface.saySomething()).isEqualTo(value);
+    }
+}

--- a/modules/module-test/mockito/junit4-java8/src/test/java/samples/powermockito/junit4/bugs/github510/FizzBuzzTest.java
+++ b/modules/module-test/mockito/junit4-java8/src/test/java/samples/powermockito/junit4/bugs/github510/FizzBuzzTest.java
@@ -1,0 +1,47 @@
+package samples.powermockito.junit4.bugs.github510;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+/**
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(FizzBuzz.class)
+public class FizzBuzzTest extends TestCase {
+
+    public static final int ANY_NUMBER = 5;
+
+    public void testFizzOnThreeShouldReturnFalse() {
+        assertThat(FizzBuzz.isFizz(3)).isFalse();
+    }
+
+    public void testFizzOnFiveShouldReturnTrue() {
+        assertThat(FizzBuzz.isFizz(5)).isTrue();
+    }
+
+    @Test
+    public void acceptOutputsFizzForFizz() {
+        PrintStream stream = mock(PrintStream.class);
+
+        PowerMockito.spy(FizzBuzz.class);
+        Mockito.when(FizzBuzz.isFizz(ANY_NUMBER)).thenReturn(true);
+
+        FizzBuzz.run(stream, 10);
+
+        Mockito.verify(stream, times(10)).println(eq("fizz"));
+    }
+}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github510/package-info.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github510/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * https://github.com/jayway/powermock/issues/510
+ */
+package samples.powermockito.junit4.bugs.github510;

--- a/modules/module-test/mockito/pom.xml
+++ b/modules/module-test/mockito/pom.xml
@@ -63,6 +63,7 @@
 
     <modules>
         <module>junit4</module>
+        <module>junit4-java8</module>
         <module>junit49</module>
         <module>junit4-rule-objenesis</module>
         <module>junit4-rule-xstream</module>

--- a/modules/module-test/pom.xml
+++ b/modules/module-test/pom.xml
@@ -21,4 +21,13 @@
         <module>mockito</module>
         <module>testng</module>
     </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -20,11 +20,4 @@
         <module>module-test</module>
     </modules>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.3.0</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -29,10 +30,12 @@
     <url>http://www.powermock.org</url>
     <description>
         PowerMock allows you to unit test code normally regarded as untestable.
-        For instance it is possible to mock static methods, remove static initializers, allow mocking without dependency injection and more.
+        For instance it is possible to mock static methods, remove static initializers, allow mocking without dependency
+        injection and more.
         PowerMock works by bytecode manipulation.
         PowerMock also contain some utilities that gives you easier access to an objects internal state.
-        PowerMock can be used to test otherwise untestable code and also to achieve a cleaner separation between test and production code.
+        PowerMock can be used to test otherwise untestable code and also to achieve a cleaner separation between test
+        and production code.
     </description>
     <inceptionYear>2007</inceptionYear>
     <licenses>
@@ -356,6 +359,12 @@
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
                 <version>2.2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.3.0</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fix 
- #510 Static method mocking with Mockito 1.9.5 and Powermock fails with Java 8 Consumer Interface
- Issue with mocking static method in interfaces.