### PR TITLE
Ensuring JVM method size limit is never exceeded

### DIFF
--- a/core/src/main/java/org/powermock/core/transformers/impl/ClassMockTransformer.java
+++ b/core/src/main/java/org/powermock/core/transformers/impl/ClassMockTransformer.java
@@ -65,6 +65,8 @@ public class ClassMockTransformer extends AbstractMainMockTransformer {
             clazz.instrument(new PowerMockExpressionEditor(clazz));
         }
 
+        ensureJvmMethodSizeLimit(clazz);
+
         return clazz;
     }
 

--- a/core/src/test/java/powermock/test/support/ClassWithLargeMethods.java
+++ b/core/src/test/java/powermock/test/support/ClassWithLargeMethods.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package powermock.test.support;
+
+public class ClassWithLargeMethods {
+
+    public static class MethodLowerThanLimit {
+        /**
+         * Method size after instrumentation is equal to 42989
+         */
+        public static String init() {
+            String a = "A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            return a;
+        }
+    }
+
+    public static class MethodGreaterThanLimit {
+        /**
+         * Method size after instrumentation is equal to 79522
+         */
+        public static String init() {
+            String a = "A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+            String b = "B";
+            b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";
+            b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";
+            b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";
+            b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";
+            b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";
+            b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";
+            b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";b+="B";
+            return a + b;
+        }
+    }
+}

--- a/modules/module-test/easymock/junit4-agent/src/test/java/samples/powermockito/junit4/agent/LargeMethodTest.java
+++ b/modules/module-test/easymock/junit4-agent/src/test/java/samples/powermockito/junit4/agent/LargeMethodTest.java
@@ -1,0 +1,58 @@
+package samples.powermockito.junit4.agent;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import samples.largemethod.MethodExceedingJvmLimit;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.method;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replayAll;
+import static org.powermock.api.easymock.PowerMock.suppress;
+
+@PrepareForTest(MethodExceedingJvmLimit.class)
+public class LargeMethodTest {
+
+    @Rule
+    public PowerMockRule powerMockRule = new PowerMockRule();
+
+    @Test
+    public void largeMethodShouldBeOverridden() {
+        try {
+            MethodExceedingJvmLimit.init();
+            fail("Method should be overridden and exception should be thrown");
+        } catch (Exception e) {
+            assertSame(IllegalAccessException.class, e.getClass());
+            assertTrue(e.getMessage().contains("Method was too large and after instrumentation exceeded JVM limit"));
+        }
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeSuppressed() {
+        suppress(method(MethodExceedingJvmLimit.class, "init"));
+        assertNull("Suppressed method should return: null", MethodExceedingJvmLimit.init());
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeMocked() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        expect(MethodExceedingJvmLimit.init()).andReturn("ok");
+        replayAll();
+        assertEquals("Mocked method should return: ok", "ok", MethodExceedingJvmLimit.init());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void largeMethodShouldBeAbleToBeMockedAndThrowException() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        expect(MethodExceedingJvmLimit.init()).andThrow(new IllegalStateException());
+        replayAll();
+        MethodExceedingJvmLimit.init();
+    }
+}

--- a/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/largemethod/LargeMethodTest.java
+++ b/modules/module-test/easymock/junit4-test/src/test/java/samples/junit4/largemethod/LargeMethodTest.java
@@ -1,0 +1,73 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package samples.junit4.largemethod;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import samples.largemethod.MethodExceedingJvmLimit;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.method;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replayAll;
+import static org.powermock.api.easymock.PowerMock.suppress;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(MethodExceedingJvmLimit.class)
+public class LargeMethodTest {
+
+    @Test
+    public void largeMethodShouldBeOverridden() {
+        try {
+            MethodExceedingJvmLimit.init();
+            fail("Method should be overridden and exception should be thrown");
+        } catch (Exception e) {
+            assertSame(IllegalAccessException.class, e.getClass());
+            assertTrue(e.getMessage().contains("Method was too large and after instrumentation exceeded JVM limit"));
+        }
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeSuppressed() {
+        suppress(method(MethodExceedingJvmLimit.class, "init"));
+        assertNull("Suppressed method should return: null", MethodExceedingJvmLimit.init());
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeMocked() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        expect(MethodExceedingJvmLimit.init()).andReturn("ok");
+        replayAll();
+        assertEquals("Mocked method should return: ok", "ok", MethodExceedingJvmLimit.init());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void largeMethodShouldBeAbleToBeMockedAndThrowException() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        expect(MethodExceedingJvmLimit.init()).andThrow(new IllegalStateException());
+        replayAll();
+        MethodExceedingJvmLimit.init();
+    }
+}

--- a/modules/module-test/mockito/junit4-agent/src/test/java/samples/powermockito/junit4/agent/LargeMethodTest.java
+++ b/modules/module-test/mockito/junit4-agent/src/test/java/samples/powermockito/junit4/agent/LargeMethodTest.java
@@ -1,0 +1,58 @@
+package samples.powermockito.junit4.agent;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import samples.largemethod.MethodExceedingJvmLimit;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
+import static org.powermock.api.support.membermodification.MemberModifier.suppress;
+
+@PrepareForTest(MethodExceedingJvmLimit.class)
+public class LargeMethodTest {
+
+    @Rule
+    public PowerMockRule powerMockRule = new PowerMockRule();
+
+    @Test
+    public void largeMethodShouldBeOverridden() {
+        try {
+            MethodExceedingJvmLimit.init();
+            fail("Method should be overridden and exception should be thrown");
+        } catch (Exception e) {
+            assertSame(IllegalAccessException.class, e.getClass());
+            assertTrue(e.getMessage().contains("Method was too large and after instrumentation exceeded JVM limit"));
+        }
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeSuppressed() {
+        suppress(method(MethodExceedingJvmLimit.class, "init"));
+        assertNull("Suppressed method should return: null", MethodExceedingJvmLimit.init());
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeMocked() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        when(MethodExceedingJvmLimit.init()).thenReturn("ok");
+        assertEquals("Mocked method should return: ok", "ok", MethodExceedingJvmLimit.init());
+        verifyStatic();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void largeMethodShouldBeAbleToBeMockedAndThrowException() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        when(MethodExceedingJvmLimit.init()).thenThrow(new IllegalStateException());
+        MethodExceedingJvmLimit.init();
+        verifyStatic();
+    }
+}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/largemethod/LargeMethodTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/largemethod/LargeMethodTest.java
@@ -1,0 +1,56 @@
+package samples.powermockito.junit4.largemethod;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import samples.largemethod.MethodExceedingJvmLimit;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.support.membermodification.MemberModifier.suppress;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(MethodExceedingJvmLimit.class)
+public class LargeMethodTest {
+
+    @Test
+    public void largeMethodShouldBeOverridden() {
+        try {
+            MethodExceedingJvmLimit.init();
+            fail("Method should be overridden and exception should be thrown");
+        } catch (Exception e) {
+            assertSame(IllegalAccessException.class, e.getClass());
+            assertTrue(e.getMessage().contains("Method was too large and after instrumentation exceeded JVM limit"));
+        }
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeSuppressed() {
+        suppress(PowerMockito.method(MethodExceedingJvmLimit.class, "init"));
+        assertNull("Suppressed method should return: null", MethodExceedingJvmLimit.init());
+    }
+
+    @Test
+    public void largeMethodShouldBeAbleToBeMocked() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        when(MethodExceedingJvmLimit.init()).thenReturn("ok");
+        assertEquals("Mocked method should return: ok", "ok", MethodExceedingJvmLimit.init());
+        verifyStatic();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void largeMethodShouldBeAbleToBeMockedAndThrowException() {
+        mockStatic(MethodExceedingJvmLimit.class);
+        when(MethodExceedingJvmLimit.init()).thenThrow(new IllegalStateException());
+        MethodExceedingJvmLimit.init();
+        verifyStatic();
+    }
+}

--- a/tests/utils/src/main/java/samples/largemethod/MethodExceedingJvmLimit.java
+++ b/tests/utils/src/main/java/samples/largemethod/MethodExceedingJvmLimit.java
@@ -1,0 +1,49 @@
+/*
+ *   Copyright 2016 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package samples.largemethod;
+
+/**
+ * Example of class with method which after instrumentation is larger than JVM limit.
+ */
+public class MethodExceedingJvmLimit {
+
+	/**
+	 * Method size after instrumentation is equal to 91265.
+	 */
+	public static String init() {
+		String a = "A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";a+="A";
+		return a;
+	}
+}


### PR DESCRIPTION
Negative consequence of code instrumentation is significant increase in code size. It can be especially problematic for large methods. When JVM limit is exceeded class loader is not able to load problematic class. This is manifested to user with enigmatic exception like:

    Exception in thread "main" java.lang.ClassFormatError: Invalid method Code length 91299 in class file com/test/SomeClass

The solution to that problem is to override excessive method to throw more descriptive exception and allow users to mock/suppress such method.

More details on JVM method size limit: http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.3