### PR TITLE
Fix #673: Add support for setting private static final fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 .settings
 .springBeans
 repo
+.idea

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Change log next version
 -----------------------
 * Fix #668 @Mock fields are not injected anymore (1.6.5 regression)
 * Renamed org.powermock.reflect.internal.WhiteboxImpl.getAllMetodsExcept to org.powermock.reflect.internal.WhiteboxImpl.getAllMethodsExcept (typo)
+* Added support for setting private static final fields in Whitebox.setInternalState
 
 Change log 1.6.5 (2015-04-30)
 -----------------------------

--- a/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -2325,9 +2325,19 @@ public class WhiteboxImpl {
     }
 
     private static void checkIfCanSetNewValue(Field fieldToSetNewValueTo) {
-        boolean fieldTypeIsPrimitive = fieldToSetNewValueTo.getType().isPrimitive();
-        if (fieldTypeIsPrimitive) {
-            throw new IllegalArgumentException("You are trying to set a private static final primitive. Try using an object like Integer instead of int!");
+        int fieldModifiersMask = fieldToSetNewValueTo.getModifiers();
+        boolean isFinalModifierPresent = (fieldModifiersMask & Modifier.FINAL) == Modifier.FINAL;
+        boolean isStaticModifierPresent = (fieldModifiersMask & Modifier.STATIC) == Modifier.STATIC;
+
+        if(isFinalModifierPresent && isStaticModifierPresent){
+            boolean fieldTypeIsPrimitive = fieldToSetNewValueTo.getType().isPrimitive();
+            if (fieldTypeIsPrimitive) {
+                throw new IllegalArgumentException("You are trying to set a private static final primitive. Try using an object like Integer instead of int!");
+            }
+            boolean fieldTypeIsString = fieldToSetNewValueTo.getType().equals(String.class);
+            if (fieldTypeIsString) {
+                throw new IllegalArgumentException("You are trying to set a private static final String. Cannot set such fields!");
+            }
         }
     }
 

--- a/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -2318,8 +2318,16 @@ public class WhiteboxImpl {
         int fieldModifiersMask = fieldToRemoveFinalFrom.getModifiers();
         boolean isFinalModifierPresent = (fieldModifiersMask & Modifier.FINAL) == Modifier.FINAL;
         if (isFinalModifierPresent) {
+            checkIfCanSetNewValue(fieldToRemoveFinalFrom);
             int fieldModifiersMaskWithoutFinal = fieldModifiersMask & ~Modifier.FINAL;
             sedModifiersToField(fieldToRemoveFinalFrom, fieldModifiersMaskWithoutFinal);
+        }
+    }
+
+    private static void checkIfCanSetNewValue(Field fieldToSetNewValueTo) {
+        boolean fieldTypeIsPrimitive = fieldToSetNewValueTo.getType().isPrimitive();
+        if (fieldTypeIsPrimitive) {
+            throw new IllegalArgumentException("You are trying to set a private static final primitive. Try using an object like Integer instead of int!");
         }
     }
 

--- a/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
+++ b/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
@@ -270,12 +270,15 @@ public class WhiteBoxTest {
 	}
 
 	@Test
-	public void testStaticFinalState() {
+	public void testStaticFinalState() throws NoSuchFieldException {
+		int modifiersBeforeSet = ClassWithInternalState.class.getDeclaredField("staticFinalStateInteger").getModifiers();
 		Integer newValue = ClassWithInternalState.getStaticFinalStateInteger() + 1;
 
 		Whitebox.setInternalState(ClassWithInternalState.class, "staticFinalStateInteger", newValue);
 
+		int modifiersAfterSet = ClassWithInternalState.class.getDeclaredField("staticFinalStateInteger").getModifiers();
 		assertEquals(newValue, ClassWithInternalState.getStaticFinalStateInteger());
+		assertEquals(modifiersBeforeSet, modifiersAfterSet);
 	}
 
 	/**

--- a/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
+++ b/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
@@ -283,6 +283,14 @@ public class WhiteBoxTest {
 	}
 
 	@Test
+	public void testStaticFinalStringState() throws NoSuchFieldException {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("You are trying to set a private static final String. Cannot set such fields!");
+
+		Whitebox.setInternalState(ClassWithInternalState.class, "staticFinalStringState", "Brand new string");
+	}
+
+	@Test
 	public void testStaticFinalObject() throws NoSuchFieldException {
 		int modifiersBeforeSet = ClassWithInternalState.class.getDeclaredField("staticFinalIntegerState").getModifiers();
 		Integer newValue = ClassWithInternalState.getStaticFinalIntegerState() + 1;
@@ -549,7 +557,7 @@ public class WhiteBoxTest {
 	@Test
 	public void testGetAllStaticFields() throws Exception {
 		Set<Field> allFields = Whitebox.getAllStaticFields(ClassWithInternalState.class);
-		assertEquals(3, allFields.size());
+		assertEquals(4, allFields.size());
 	}
 
 	@Test

--- a/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
+++ b/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
@@ -269,10 +269,13 @@ public class WhiteBoxTest {
 		assertEquals(expected, Whitebox.getInternalState(ClassWithInternalState.class, "staticState"));
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testStaticFinalState() {
-		Whitebox.setInternalState(ClassWithInternalState.class, "staticFinalState", 123);
-		fail("Static final is not possible to change");
+		Integer newValue = ClassWithInternalState.getStaticFinalStateInteger() + 1;
+
+		Whitebox.setInternalState(ClassWithInternalState.class, "staticFinalStateInteger", newValue);
+
+		assertEquals(newValue, ClassWithInternalState.getStaticFinalStateInteger());
 	}
 
 	/**
@@ -530,7 +533,7 @@ public class WhiteBoxTest {
 	@Test
 	public void testGetAllStaticFields() throws Exception {
 		Set<Field> allFields = Whitebox.getAllStaticFields(ClassWithInternalState.class);
-		assertEquals(2, allFields.size());
+		assertEquals(3, allFields.size());
 	}
 
 	@Test

--- a/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
+++ b/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
@@ -16,7 +16,9 @@
 package org.powermock.reflect;
 
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.powermock.reflect.context.ClassFieldsNotInTargetContext;
 import org.powermock.reflect.context.InstanceFieldsNotInTargetContext;
 import org.powermock.reflect.context.MyContext;
@@ -78,6 +80,9 @@ import static org.junit.Assert.fail;
  * Tests the WhiteBox's functionality.
  */
 public class WhiteBoxTest {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	static {
 		RegisterProxyFramework.registerProxyFramework(new ProxyFramework() {
@@ -270,14 +275,22 @@ public class WhiteBoxTest {
 	}
 
 	@Test
-	public void testStaticFinalState() throws NoSuchFieldException {
-		int modifiersBeforeSet = ClassWithInternalState.class.getDeclaredField("staticFinalStateInteger").getModifiers();
-		Integer newValue = ClassWithInternalState.getStaticFinalStateInteger() + 1;
+	public void testStaticFinalPrimitiveState() {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("You are trying to set a private static final primitive. Try using an object like Integer instead of int!");
 
-		Whitebox.setInternalState(ClassWithInternalState.class, "staticFinalStateInteger", newValue);
+		Whitebox.setInternalState(ClassWithInternalState.class, "staticFinalIntState", 123);
+	}
 
-		int modifiersAfterSet = ClassWithInternalState.class.getDeclaredField("staticFinalStateInteger").getModifiers();
-		assertEquals(newValue, ClassWithInternalState.getStaticFinalStateInteger());
+	@Test
+	public void testStaticFinalObject() throws NoSuchFieldException {
+		int modifiersBeforeSet = ClassWithInternalState.class.getDeclaredField("staticFinalIntegerState").getModifiers();
+		Integer newValue = ClassWithInternalState.getStaticFinalIntegerState() + 1;
+
+		Whitebox.setInternalState(ClassWithInternalState.class, "staticFinalIntegerState", newValue);
+
+		int modifiersAfterSet = ClassWithInternalState.class.getDeclaredField("staticFinalIntegerState").getModifiers();
+		assertEquals(newValue, ClassWithInternalState.getStaticFinalIntegerState());
 		assertEquals(modifiersBeforeSet, modifiersAfterSet);
 	}
 

--- a/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInternalState.java
+++ b/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInternalState.java
@@ -23,9 +23,9 @@ public class ClassWithInternalState {
 
     private static int staticState = 5;
 
-    private static final int staticFinalState = 15;
+    private static final int staticFinalIntState = 15;
 
-    private static final Integer staticFinalStateInteger = 15;
+    private static final Integer staticFinalIntegerState = 15;
 
     private int internalState = 0;
 
@@ -61,12 +61,8 @@ public class ClassWithInternalState {
         return staticState;
     }
 
-    public static int getStaticFinalState() {
-        return staticFinalState;
-    }
-
-    public static Integer getStaticFinalStateInteger() {
-        return staticFinalStateInteger;
+    public static Integer getStaticFinalIntegerState() {
+        return staticFinalIntegerState;
     }
 
     public ClassWithPrivateMethods getClassWithPrivateMethods() {

--- a/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInternalState.java
+++ b/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInternalState.java
@@ -25,6 +25,8 @@ public class ClassWithInternalState {
 
     private static final int staticFinalState = 15;
 
+    private static final Integer staticFinalStateInteger = 15;
+
     private int internalState = 0;
 
     private int anotherInternalState = -1;
@@ -61,6 +63,10 @@ public class ClassWithInternalState {
 
     public static int getStaticFinalState() {
         return staticFinalState;
+    }
+
+    public static Integer getStaticFinalStateInteger() {
+        return staticFinalStateInteger;
     }
 
     public ClassWithPrivateMethods getClassWithPrivateMethods() {

--- a/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInternalState.java
+++ b/reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithInternalState.java
@@ -27,6 +27,8 @@ public class ClassWithInternalState {
 
     private static final Integer staticFinalIntegerState = 15;
 
+    private static final String staticFinalStringState = "Some String";
+
     private int internalState = 0;
 
     private int anotherInternalState = -1;


### PR DESCRIPTION
Here is the [issue I reported](https://github.com/jayway/powermock/issues/673)

Whitebox.setInternalState works with [private static final object](https://github.com/andreicristianpetcu/powermock/blob/6a2ce1d15221f87e192c8402b76d93f2b74e6d47/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java#L293-L303)
```java
Whitebox.setInternalState(ClassWithInternalState.class, 
    "staticFinalIntegerState", newValue);
```
Whitebox.setInternalState throws exception with private static final [primitive](https://github.com/andreicristianpetcu/powermock/blob/6a2ce1d15221f87e192c8402b76d93f2b74e6d47/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java#L277-L283) or [String](https://github.com/andreicristianpetcu/powermock/blob/6a2ce1d15221f87e192c8402b76d93f2b74e6d47/reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java#L285-L291). The primitive exception suggests using an object instead of the primitive.