### PR TITLE
Fix #676: Do not mock class annotations

### DIFF
--- a/core/src/main/java/org/powermock/core/MockGateway.java
+++ b/core/src/main/java/org/powermock/core/MockGateway.java
@@ -58,7 +58,7 @@ public class MockGateway {
 
     /**
      * Tells PowerMock whether or not to mock
-     * {@link java.lang.Class#isAnnotationPresent(Class)} ()} and
+     * {@link java.lang.Class#isAnnotationPresent(Class)} and
      * {@link java.lang.Class#getAnnotation(Class)}.
      */
     public static boolean MOCK_ANNOTATION_METHODS = false;

--- a/core/src/main/java/org/powermock/core/MockGateway.java
+++ b/core/src/main/java/org/powermock/core/MockGateway.java
@@ -56,6 +56,13 @@ public class MockGateway {
      */
     public static boolean MOCK_GET_CLASS_METHOD = false;
 
+    /**
+     * Tells PowerMock whether or not to mock
+     * {@link java.lang.Class#isAnnotationPresent(Class)} ()} and
+     * {@link java.lang.Class#getAnnotation(Class)}.
+     */
+    public static boolean MOCK_ANNOTATION_METHODS = false;
+
     // used for static methods
     @SuppressWarnings("UnusedDeclaration")
     public static Object methodCall(Class<?> type, String methodName, Object[] args, Class<?>[] sig,
@@ -161,6 +168,8 @@ public class MockGateway {
             return false;
         } else if (isGetClassMethod(methodName, sig) && !MOCK_GET_CLASS_METHOD) {
             return false;
+        } else if (isAnnotationMethod(methodName, sig) && !MOCK_ANNOTATION_METHODS){
+            return false;
         } else {
             return true;
         }
@@ -173,6 +182,10 @@ public class MockGateway {
 
     private static boolean isGetClassMethod(String methodName, Class<?>[] sig) {
         return methodName.equals("getClass") && sig.length == 0;
+    }
+    
+    private static boolean isAnnotationMethod(String methodName, Class<?>[] sig) {
+        return (methodName.equals("isAnnotationPresent") && sig.length == 1) || (methodName.equals("getAnnotation") && sig.length == 1);
     }
 
     private static boolean shouldMockThisCall() {

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/getannotation/GetAnnotationTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/getannotation/GetAnnotationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package samples.powermockito.junit4.getannotation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.MockGateway;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import samples.annotationbased.AnnotatedClassDemo;
+import samples.annotationbased.testannotations.RuntimeAnnotation;
+
+import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+/**
+ * Assert that "isAnnotationPresent" and "getAnnotation" works correctly when mockStatic is used
+ * @see <a href="https://github.com/jayway/powermock/issues/676">Issue 676</a>
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AnnotatedClassDemo.class)
+public class GetAnnotationTest {
+
+    @Before
+    public void setUp() {
+        mockStatic(AnnotatedClassDemo.class);
+        when(AnnotatedClassDemo.staticMethod()).thenReturn(true);
+    }
+
+    @Test
+    public void getClassAnnotationsReturnActualAnnotationsByDefault() throws Exception {
+        assertTrue(AnnotatedClassDemo.class.isAnnotationPresent(RuntimeAnnotation.class));
+        assertNotNull(AnnotatedClassDemo.class.getAnnotation(RuntimeAnnotation.class));
+        assertTrue(AnnotatedClassDemo.staticMethod());
+    }
+
+    @Test
+    public void nonExistingAnnotationsAreNotReturnedByDefault() throws Exception {
+        assertFalse(AnnotatedClassDemo.class.isAnnotationPresent(Deprecated.class));
+        assertNull(AnnotatedClassDemo.class.getAnnotation(Deprecated.class));
+        assertTrue(AnnotatedClassDemo.staticMethod());
+    }
+
+    // behavior before the fix:
+    
+    @Test
+    public void isAnnotationPresentReturnsFalseWhenMethodsAreMocked() throws Exception {
+        MockGateway.MOCK_ANNOTATION_METHODS = true;
+        try {
+            assertFalse(AnnotatedClassDemo.class.isAnnotationPresent(RuntimeAnnotation.class));
+            assertTrue(AnnotatedClassDemo.staticMethod());
+        } finally {
+            MockGateway.MOCK_ANNOTATION_METHODS = false;
+        }
+    }
+
+    @Test
+    public void getAnnotationReturnsNullWhenMethodsAreMocked() throws Exception {
+        MockGateway.MOCK_ANNOTATION_METHODS = true;
+        try {
+            assertNull(AnnotatedClassDemo.class.getAnnotation(RuntimeAnnotation.class));
+            assertTrue(AnnotatedClassDemo.staticMethod());
+        } finally {
+            MockGateway.MOCK_ANNOTATION_METHODS = false;
+        }
+    }
+}

--- a/tests/utils/src/main/java/samples/annotationbased/AnnotatedClassDemo.java
+++ b/tests/utils/src/main/java/samples/annotationbased/AnnotatedClassDemo.java
@@ -1,0 +1,10 @@
+package samples.annotationbased;
+
+import samples.annotationbased.testannotations.RuntimeAnnotation;
+
+@RuntimeAnnotation
+public class AnnotatedClassDemo {
+    public static boolean staticMethod() {
+        return false;
+    }
+}

--- a/tests/utils/src/main/java/samples/annotationbased/testannotations/RuntimeAnnotation.java
+++ b/tests/utils/src/main/java/samples/annotationbased/testannotations/RuntimeAnnotation.java
@@ -1,0 +1,12 @@
+package samples.annotationbased.testannotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {TYPE})
+public @interface RuntimeAnnotation {
+}


### PR DESCRIPTION
This is a fix for #676 

Powermock will no longer mock the class methods 
`isAnnotationPresent(Class)` and `getAnnotation(Class)`
and instead return the actual values.
