### PR TITLE
powermock-688 powermock searches only for "java." 

### DIFF
--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github668/GitHub668Test.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github668/GitHub668Test.java
@@ -1,0 +1,31 @@
+package samples.powermockito.junit4.bugs.github668;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.security.auth.Subject;
+
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Subject.class)
+public class GitHub668Test {
+
+    @Test
+    public void shouldMockJavaxSystemFinalClasses() {
+        Subject subject = mock(Subject.class);
+
+        final HashSet<Object> value = new HashSet<Object>();
+        when(subject.getPrivateCredentials()).thenReturn(value);
+
+        assertThat(subject.getPrivateCredentials()).isSameAs(value);
+    }
+
+}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github668/package-info.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github668/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * https://github.com/jayway/powermock/issues/688
+ */
+package samples.powermockito.junit4.bugs.github668;


### PR DESCRIPTION
powermock searches only for "java."  when checking if type is java system class
Create test - all work fine. 