### PR TITLE
#704 PowerMockito 1.6.5 throws java.lang.SecurityException signer information mismatch

### DIFF
--- a/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
+++ b/core/src/main/java/org/powermock/core/classloader/MockClassLoader.java
@@ -189,7 +189,7 @@ public class MockClassLoader extends DeferSupportingClassLoader {
 
         Class<?> deferClass = deferTo.loadClass(s);
         if (shouldModify(s) && !shouldLoadWithMockClassloaderWithoutModifications(s)) {
-            loadedClass = loadMockClass(s);
+            loadedClass = loadMockClass(s, deferClass.getProtectionDomain());
         } else {
             loadedClass = loadUnmockedClass(s, deferClass.getProtectionDomain());
         }
@@ -253,7 +253,7 @@ public class MockClassLoader extends DeferSupportingClassLoader {
     /**
      * Load a mocked version of the class.
      */
-    private Class<?> loadMockClass(String name) {
+    private Class<?> loadMockClass(String name, ProtectionDomain protectionDomain) {
 
         final byte[] clazz;
 
@@ -284,7 +284,7 @@ public class MockClassLoader extends DeferSupportingClassLoader {
                     + e.getMessage(), e);
         }
 
-        return defineClass(name, clazz, 0, clazz.length);
+        return defineClass(name, clazz, 0, clazz.length, protectionDomain);
     }
 
     public void setMockTransformerChain(List<MockTransformer> mockTransformerChain) {

--- a/modules/module-test/mockito/junit4/pom.xml
+++ b/modules/module-test/mockito/junit4/pom.xml
@@ -28,6 +28,12 @@
             <version>0.7.5.201505241946</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>core</artifactId>
+            <version>3.3.0-v_771</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github704/PrepareForTestSignedTest.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github704/PrepareForTestSignedTest.java
@@ -1,0 +1,28 @@
+package samples.powermockito.junit4.bugs.github704;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SomeClassUseSignedClasses.class, FileLocator.class})
+public class PrepareForTestSignedTest {
+
+    @Test
+    public void shouldBeAbleMockSignedClasses(){
+        FileLocator fileLocator = mock(FileLocator.class);
+
+        mockStatic(SomeClassUseSignedClasses.class);
+
+        when(SomeClassUseSignedClasses.getFileLocator()).thenReturn(fileLocator);
+
+        assertThat(SomeClassUseSignedClasses.getFileLocator()).isNotNull();
+    }
+}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github704/SomeClassUseSignedClasses.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github704/SomeClassUseSignedClasses.java
@@ -1,0 +1,11 @@
+package samples.powermockito.junit4.bugs.github704;
+
+import org.eclipse.core.runtime.FileLocator;
+
+public class SomeClassUseSignedClasses {
+
+    public static FileLocator getFileLocator(){
+        return null;
+    }
+
+}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github704/package-info.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github704/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * PowerMockito 1.6.5 throws java.lang.SecurityException signer information mismatch if in the PrepareForTest annotation affects also classes which have signatures
+ * https://github.com/jayway/powermock/issues/704
+ */
+package samples.powermockito.junit4.bugs.github704;


### PR DESCRIPTION
Fix #704 Pass protection domain for mocked classes