### PR TITLE
Optimizations in powermock-reflect

### DIFF
--- a/core/src/main/java/org/powermock/core/MockGateway.java
+++ b/core/src/main/java/org/powermock/core/MockGateway.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Modifier;
  */
 public class MockGateway {
 
+    private static boolean noMockito = Package.getPackage("org.mockito") == null;
     public static final Object PROCEED = new Object();
     public static final Object SUPPRESS = new Object();
 
@@ -226,6 +227,9 @@ public class MockGateway {
     }
 
     private static boolean calledFromMockito() {
+        if (noMockito) {
+            return false;
+        }
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         for (StackTraceElement stackTraceElement : stackTrace) {
             if (stackTraceElement.getClassName().startsWith("org.mockito.")){

--- a/core/src/main/java/org/powermock/core/MockGateway.java
+++ b/core/src/main/java/org/powermock/core/MockGateway.java
@@ -33,7 +33,14 @@ import java.lang.reflect.Modifier;
  */
 public class MockGateway {
 
-    private static boolean noMockito = Package.getPackage("org.mockito") == null;
+    /**
+     * {@link #noMockito} is wrapped into it's own static class to make sure it is initialized not earlier than
+     * {@link #calledFromMockito()} is called for the first time.
+     */
+    private static final class NoMockito {
+        static final boolean noMockito = Package.getPackage("org.mockito") == null;
+        private NoMockito() {}
+    }
     public static final Object PROCEED = new Object();
     public static final Object SUPPRESS = new Object();
 
@@ -227,7 +234,7 @@ public class MockGateway {
     }
 
     private static boolean calledFromMockito() {
-        if (noMockito) {
+        if (NoMockito.noMockito) {
             return false;
         }
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();

--- a/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -57,6 +57,8 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Various utilities for accessing internals of a class. Basically a simplified
@@ -68,6 +70,12 @@ public class WhiteboxImpl {
      * The proxy framework.
      */
     private static ProxyFrameworks proxyFrameworks = new ProxyFrameworks();
+
+    /**
+     * "Strong" map prevent class and method objects from being GCed and unloaded.
+     * TODO replace with ClassValue when Powermock drops Java 6 support.
+     */
+    private static ConcurrentMap<Class, Method[]> allClassMethodsCache = new ConcurrentHashMap<>();
 
     /**
      * Convenience method to get a method from a class type without having to
@@ -1448,6 +1456,17 @@ public class WhiteboxImpl {
      * @return All methods declared in this class hierarchy.
      */
     public static Method[] getAllMethods(Class<?> clazz) {
+        Method[] allMethods = allClassMethodsCache.get(clazz);
+        if (allMethods == null) {
+            // Allows a race between concurrent threads coming for clazz's methods at the same time,
+            // but the race seems to be harmless.
+            allMethods = doGetAllMethods(clazz);
+            allClassMethodsCache.put(clazz, allMethods);
+        }
+        return allMethods;
+    }
+
+    private static Method[] doGetAllMethods(Class<?> clazz) {
         if (clazz == null) {
             throw new IllegalArgumentException("You must specify a class in order to get the methods.");
         }

--- a/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -75,7 +75,7 @@ public class WhiteboxImpl {
      * "Strong" map prevent class and method objects from being GCed and unloaded.
      * TODO replace with ClassValue when Powermock drops Java 6 support.
      */
-    private static ConcurrentMap<Class, Method[]> allClassMethodsCache = new ConcurrentHashMap<>();
+    private static ConcurrentMap<Class, Method[]> allClassMethodsCache = new ConcurrentHashMap<Class, Method[]>();
 
     /**
      * Convenience method to get a method from a class type without having to


### PR DESCRIPTION
When I started to use Powermock instead of Easymock, some test which used to take seconds started to take more than one minute. The proposed changes make performance of Powermock more or less comparable with Easymock.